### PR TITLE
Function and variable renaming for consistency and clarity

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,10 +1,7 @@
 {
     "extends": "solhint:recommended",
     "rules": {
-        "max-states-count": [
-            "warn",
-            15
-        ],
+        "max-states-count": "off",
         "max-line-length": [
             "error",
             120

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # 🔮 Orb Contract • [![test](https://github.com/orbland/orb/actions/workflows/ci.yml/badge.svg)](https://github.com/orbland/orb/actions/workflows/ci.yml) ![license](https://img.shields.io/badge/License-MIT-green.svg?label=license)
 
-Auction + Harberger taxed ownership. Used by [orb.land](https://orb.land). Uses Forge toolkit for building and testing. Contract combines the following areas of functionality:
+Auction + Harberger taxed ownership. Used by [orb.land](https://orb.land). Uses Forge toolkit for building and testing. The contract combines the following areas of functionality:
 
 - **Auction.** Allows the contract owner to start the Orb auction, determining the first owner of the Orb.
 - **Funds management.** Allows any user to deposit and withdraw funds. Funds are used to make auction bids and pay Harberger Tax.
 - **Harberger Tax.** Uses delayed accounting (settling) to allocate funds from the current owner to the contract beneficiary, based on the price set by the owner and tax rate.
-- **On-chain Orb Invocations.** Called triggers and responses, they allow the owner to periodically invoke the Orb, requesting a response from the Orb creator.
-- **ERC-721 compatibility.** All transfers revert, but otherwise the contract appears as supporting all ERC-721 functions.
+- **On-chain Orb Invocations.** Allows the owner to periodically invoke the Orb, requesting a response from the Orb creator.
+- **ERC-721 compatibility.** All transfers revert, but otherwise, the contract appears as supporting all ERC-721 functions.
 
 The contract is fully documented in NatSpec format.
 

--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -11,7 +11,7 @@ abstract contract DeployBase is Script {
     address[] private contributorWallets;
     uint256[] private contributorShares;
 
-    address private immutable issuerWallet;
+    address private immutable creatorAddress;
     uint256 private immutable tokenId;
 
     // Deploy addresses.
@@ -21,12 +21,12 @@ abstract contract DeployBase is Script {
     constructor(
         address[] memory _contributorWallets,
         uint256[] memory _contributorShares,
-        address _issuerWallet,
+        address _creatorAddress,
         uint256 _tokenId
     ) {
         contributorWallets = _contributorWallets;
         contributorShares = _contributorShares;
-        issuerWallet = _issuerWallet;
+        creatorAddress = _creatorAddress;
         tokenId = _tokenId;
     }
 
@@ -42,7 +42,7 @@ abstract contract DeployBase is Script {
             tokenId,
             splitterAddress // beneficiary
         );
-        orb.transferOwnership(issuerWallet);
+        orb.transferOwnership(creatorAddress);
 
         vm.stopBroadcast();
     }

--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -17,7 +17,7 @@ abstract contract DeployBase is Script {
     uint256 private immutable auctionMinimumDuration;
     uint256 private immutable auctionBidExtension;
     uint256 private immutable holderTaxNumerator;
-    uint256 private immutable saleRoyaltiesNumerator;
+    uint256 private immutable royaltyNumerator;
     uint256 private immutable auctionStartingPrice;
     uint256 private immutable auctionMinimumBidStep;
 
@@ -34,7 +34,7 @@ abstract contract DeployBase is Script {
         uint256 _auctionMinimumDuration,
         uint256 _auctionBidExtension,
         uint256 _holderTaxNumerator,
-        uint256 _saleRoyaltiesNumerator,
+        uint256 _royaltyNumerator,
         uint256 _auctionStartingPrice,
         uint256 _auctionMinimumBidStep
     ) {
@@ -46,7 +46,7 @@ abstract contract DeployBase is Script {
         auctionMinimumDuration = _auctionMinimumDuration;
         auctionBidExtension = _auctionBidExtension;
         holderTaxNumerator = _holderTaxNumerator;
-        saleRoyaltiesNumerator = _saleRoyaltiesNumerator;
+        royaltyNumerator = _royaltyNumerator;
         auctionStartingPrice = _auctionStartingPrice;
         auctionMinimumBidStep = _auctionMinimumBidStep;
     }
@@ -66,7 +66,7 @@ abstract contract DeployBase is Script {
             auctionBidExtension,
             splitterAddress, // beneficiary
             holderTaxNumerator,
-            saleRoyaltiesNumerator,
+            royaltyNumerator,
             auctionStartingPrice,
             auctionMinimumBidStep
         );

--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -13,6 +13,7 @@ abstract contract DeployBase is Script {
 
     address private immutable issuerWallet;
     uint256 private immutable cooldown;
+    uint256 private immutable tokenId;
 
     // Deploy addresses.
     PaymentSplitter public orbBeneficiary;
@@ -22,11 +23,13 @@ abstract contract DeployBase is Script {
         address[] memory _contributorWallets,
         uint256[] memory _contributorShares,
         address _issuerWallet,
+        uint256 _tokenId,
         uint256 _cooldown
     ) {
         contributorWallets = _contributorWallets;
         contributorShares = _contributorShares;
         issuerWallet = _issuerWallet;
+        tokenId = _tokenId;
         cooldown = _cooldown;
     }
 
@@ -39,6 +42,7 @@ abstract contract DeployBase is Script {
         address splitterAddress = address(orbBeneficiary);
 
         orb = new Orb(
+            tokenId,
             cooldown,
             splitterAddress // beneficiary
         );

--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -15,8 +15,6 @@ abstract contract DeployBase is Script {
     uint256 private immutable cooldown;
     uint256 private immutable auctionMinimumDuration;
     uint256 private immutable auctionBidExtension;
-    uint256 private immutable holderTaxNumerator;
-    uint256 private immutable royaltyNumerator;
     uint256 private immutable auctionStartingPrice;
     uint256 private immutable auctionMinimumBidStep;
 
@@ -31,8 +29,6 @@ abstract contract DeployBase is Script {
         uint256 _cooldown,
         uint256 _auctionMinimumDuration,
         uint256 _auctionBidExtension,
-        uint256 _holderTaxNumerator,
-        uint256 _royaltyNumerator,
         uint256 _auctionStartingPrice,
         uint256 _auctionMinimumBidStep
     ) {
@@ -42,8 +38,6 @@ abstract contract DeployBase is Script {
         cooldown = _cooldown;
         auctionMinimumDuration = _auctionMinimumDuration;
         auctionBidExtension = _auctionBidExtension;
-        holderTaxNumerator = _holderTaxNumerator;
-        royaltyNumerator = _royaltyNumerator;
         auctionStartingPrice = _auctionStartingPrice;
         auctionMinimumBidStep = _auctionMinimumBidStep;
     }
@@ -61,8 +55,6 @@ abstract contract DeployBase is Script {
             auctionMinimumDuration,
             auctionBidExtension,
             splitterAddress, // beneficiary
-            holderTaxNumerator,
-            royaltyNumerator,
             auctionStartingPrice,
             auctionMinimumBidStep
         );

--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -8,8 +8,8 @@ import {PaymentSplitter} from "@openzeppelin/contracts/finance/PaymentSplitter.s
 
 abstract contract DeployBase is Script {
     // Environment specific variables.
-    address[] private contributorWallets;
-    uint256[] private contributorShares;
+    address[] private beneficiaryAddresses;
+    uint256[] private beneficiaryShares;
 
     address private immutable creatorAddress;
     uint256 private immutable tokenId;
@@ -19,13 +19,13 @@ abstract contract DeployBase is Script {
     Orb public orb;
 
     constructor(
-        address[] memory _contributorWallets,
-        uint256[] memory _contributorShares,
+        address[] memory _beneficiaryAddresses,
+        uint256[] memory _beneficiaryShares,
         address _creatorAddress,
         uint256 _tokenId
     ) {
-        contributorWallets = _contributorWallets;
-        contributorShares = _contributorShares;
+        beneficiaryAddresses = _beneficiaryAddresses;
+        beneficiaryShares = _beneficiaryShares;
         creatorAddress = _creatorAddress;
         tokenId = _tokenId;
     }
@@ -35,7 +35,7 @@ abstract contract DeployBase is Script {
 
         vm.startBroadcast(deployerKey);
 
-        orbBeneficiary = new PaymentSplitter(contributorWallets, contributorShares);
+        orbBeneficiary = new PaymentSplitter(beneficiaryAddresses, beneficiaryShares);
         address splitterAddress = address(orbBeneficiary);
 
         orb = new Orb(

--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -12,7 +12,6 @@ abstract contract DeployBase is Script {
     uint256[] private contributorShares;
 
     address private immutable issuerWallet;
-    uint256 private immutable cooldown;
     uint256 private immutable tokenId;
 
     // Deploy addresses.
@@ -23,14 +22,12 @@ abstract contract DeployBase is Script {
         address[] memory _contributorWallets,
         uint256[] memory _contributorShares,
         address _issuerWallet,
-        uint256 _tokenId,
-        uint256 _cooldown
+        uint256 _tokenId
     ) {
         contributorWallets = _contributorWallets;
         contributorShares = _contributorShares;
         issuerWallet = _issuerWallet;
         tokenId = _tokenId;
-        cooldown = _cooldown;
     }
 
     function run() external {
@@ -43,7 +40,6 @@ abstract contract DeployBase is Script {
 
         orb = new Orb(
             tokenId,
-            cooldown,
             splitterAddress // beneficiary
         );
         orb.transferOwnership(issuerWallet);

--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -13,10 +13,6 @@ abstract contract DeployBase is Script {
 
     address private immutable issuerWallet;
     uint256 private immutable cooldown;
-    uint256 private immutable auctionMinimumDuration;
-    uint256 private immutable auctionBidExtension;
-    uint256 private immutable auctionStartingPrice;
-    uint256 private immutable auctionMinimumBidStep;
 
     // Deploy addresses.
     PaymentSplitter public orbBeneficiary;
@@ -26,20 +22,12 @@ abstract contract DeployBase is Script {
         address[] memory _contributorWallets,
         uint256[] memory _contributorShares,
         address _issuerWallet,
-        uint256 _cooldown,
-        uint256 _auctionMinimumDuration,
-        uint256 _auctionBidExtension,
-        uint256 _auctionStartingPrice,
-        uint256 _auctionMinimumBidStep
+        uint256 _cooldown
     ) {
         contributorWallets = _contributorWallets;
         contributorShares = _contributorShares;
         issuerWallet = _issuerWallet;
         cooldown = _cooldown;
-        auctionMinimumDuration = _auctionMinimumDuration;
-        auctionBidExtension = _auctionBidExtension;
-        auctionStartingPrice = _auctionStartingPrice;
-        auctionMinimumBidStep = _auctionMinimumBidStep;
     }
 
     function run() external {
@@ -52,11 +40,7 @@ abstract contract DeployBase is Script {
 
         orb = new Orb(
             cooldown,
-            auctionMinimumDuration,
-            auctionBidExtension,
-            splitterAddress, // beneficiary
-            auctionStartingPrice,
-            auctionMinimumBidStep
+            splitterAddress // beneficiary
         );
         orb.transferOwnership(issuerWallet);
 

--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -13,7 +13,6 @@ abstract contract DeployBase is Script {
 
     address private immutable issuerWallet;
     uint256 private immutable cooldown;
-    uint256 private immutable responseFlaggingPeriod;
     uint256 private immutable auctionMinimumDuration;
     uint256 private immutable auctionBidExtension;
     uint256 private immutable holderTaxNumerator;
@@ -30,7 +29,6 @@ abstract contract DeployBase is Script {
         uint256[] memory _contributorShares,
         address _issuerWallet,
         uint256 _cooldown,
-        uint256 _responseFlaggingPeriod,
         uint256 _auctionMinimumDuration,
         uint256 _auctionBidExtension,
         uint256 _holderTaxNumerator,
@@ -42,7 +40,6 @@ abstract contract DeployBase is Script {
         contributorShares = _contributorShares;
         issuerWallet = _issuerWallet;
         cooldown = _cooldown;
-        responseFlaggingPeriod = _responseFlaggingPeriod;
         auctionMinimumDuration = _auctionMinimumDuration;
         auctionBidExtension = _auctionBidExtension;
         holderTaxNumerator = _holderTaxNumerator;
@@ -61,7 +58,6 @@ abstract contract DeployBase is Script {
 
         orb = new Orb(
             cooldown,
-            responseFlaggingPeriod,
             auctionMinimumDuration,
             auctionBidExtension,
             splitterAddress, // beneficiary

--- a/script/DeployGoerli.s.sol
+++ b/script/DeployGoerli.s.sol
@@ -15,22 +15,8 @@ contract DeployGoerli is DeployBase {
     address private immutable issuerWallet = 0xC0A00c8c9EF6fe6F0a79B8a616183384dbaf8EC8;
 
     uint256 private immutable cooldown = 30 minutes;
-    uint256 private immutable auctionMinimumDuration = 30 minutes;
-    uint256 private immutable auctionBidExtension = 2 minutes;
-    uint256 private immutable auctionStartingPrice = 0.1 ether;
-    uint256 private immutable auctionMinimumBidStep = 0.1 ether;
 
-    constructor()
-        DeployBase(
-            contributorWallets,
-            contributorShares,
-            issuerWallet,
-            cooldown,
-            auctionMinimumDuration,
-            auctionBidExtension,
-            auctionStartingPrice,
-            auctionMinimumBidStep
-        )
+    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, cooldown) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployGoerli.s.sol
+++ b/script/DeployGoerli.s.sol
@@ -4,18 +4,18 @@ pragma solidity ^0.8.17;
 import {DeployBase} from "./DeployBase.s.sol";
 
 contract DeployGoerli is DeployBase {
-    address[] private contributorWallets = [
+    address[] private beneficiaryAddresses = [
         0xE48C655276C23F1534AE2a87A2bf8A8A6585Df70, // ercwl.eth
         0x9F49230672c52A2b958F253134BB17Ac84d30833, // jonas.eth
         0xf374CE39E4dB1697c8D0D77F91A9234b2Fd55F62 // odysseas
     ];
-    uint256[] private contributorShares = [65, 20, 15];
+    uint256[] private beneficiaryShares = [65, 20, 15];
 
     // our test issuer
     address private immutable creatorAddress = 0xC0A00c8c9EF6fe6F0a79B8a616183384dbaf8EC8;
     uint256 private immutable tokenId = 1;
 
-    constructor() DeployBase(contributorWallets, contributorShares, creatorAddress, tokenId) 
+    constructor() DeployBase(beneficiaryAddresses, beneficiaryShares, creatorAddress, tokenId) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployGoerli.s.sol
+++ b/script/DeployGoerli.s.sol
@@ -17,8 +17,6 @@ contract DeployGoerli is DeployBase {
     uint256 private immutable cooldown = 30 minutes;
     uint256 private immutable auctionMinimumDuration = 30 minutes;
     uint256 private immutable auctionBidExtension = 2 minutes;
-    uint256 private immutable holderTaxNumerator = 1000;
-    uint256 private immutable royaltyNumerator = 1000;
     uint256 private immutable auctionStartingPrice = 0.1 ether;
     uint256 private immutable auctionMinimumBidStep = 0.1 ether;
 
@@ -30,8 +28,6 @@ contract DeployGoerli is DeployBase {
             cooldown,
             auctionMinimumDuration,
             auctionBidExtension,
-            holderTaxNumerator,
-            royaltyNumerator,
             auctionStartingPrice,
             auctionMinimumBidStep
         )

--- a/script/DeployGoerli.s.sol
+++ b/script/DeployGoerli.s.sol
@@ -19,7 +19,7 @@ contract DeployGoerli is DeployBase {
     uint256 private immutable auctionMinimumDuration = 30 minutes;
     uint256 private immutable auctionBidExtension = 2 minutes;
     uint256 private immutable holderTaxNumerator = 1000;
-    uint256 private immutable saleRoyaltiesNumerator = 1000;
+    uint256 private immutable royaltyNumerator = 1000;
     uint256 private immutable auctionStartingPrice = 0.1 ether;
     uint256 private immutable auctionMinimumBidStep = 0.1 ether;
 
@@ -33,9 +33,11 @@ contract DeployGoerli is DeployBase {
             auctionMinimumDuration,
             auctionBidExtension,
             holderTaxNumerator,
-            saleRoyaltiesNumerator,
+            royaltyNumerator,
             auctionStartingPrice,
             auctionMinimumBidStep
         )
+    /* solhint-disable no-empty-blocks */
     {}
+    /* solhint-enable no-empty-blocks */
 }

--- a/script/DeployGoerli.s.sol
+++ b/script/DeployGoerli.s.sol
@@ -13,11 +13,9 @@ contract DeployGoerli is DeployBase {
 
     // our test issuer
     address private immutable issuerWallet = 0xC0A00c8c9EF6fe6F0a79B8a616183384dbaf8EC8;
-
     uint256 private immutable tokenId = 1;
-    uint256 private immutable cooldown = 30 minutes;
 
-    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId, cooldown) 
+    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployGoerli.s.sol
+++ b/script/DeployGoerli.s.sol
@@ -15,7 +15,6 @@ contract DeployGoerli is DeployBase {
     address private immutable issuerWallet = 0xC0A00c8c9EF6fe6F0a79B8a616183384dbaf8EC8;
 
     uint256 private immutable cooldown = 30 minutes;
-    uint256 private immutable responseFlaggingPeriod = 30 minutes;
     uint256 private immutable auctionMinimumDuration = 30 minutes;
     uint256 private immutable auctionBidExtension = 2 minutes;
     uint256 private immutable holderTaxNumerator = 1000;
@@ -29,7 +28,6 @@ contract DeployGoerli is DeployBase {
             contributorShares,
             issuerWallet,
             cooldown,
-            responseFlaggingPeriod,
             auctionMinimumDuration,
             auctionBidExtension,
             holderTaxNumerator,

--- a/script/DeployGoerli.s.sol
+++ b/script/DeployGoerli.s.sol
@@ -12,10 +12,10 @@ contract DeployGoerli is DeployBase {
     uint256[] private contributorShares = [65, 20, 15];
 
     // our test issuer
-    address private immutable issuerWallet = 0xC0A00c8c9EF6fe6F0a79B8a616183384dbaf8EC8;
+    address private immutable creatorAddress = 0xC0A00c8c9EF6fe6F0a79B8a616183384dbaf8EC8;
     uint256 private immutable tokenId = 1;
 
-    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId) 
+    constructor() DeployBase(contributorWallets, contributorShares, creatorAddress, tokenId) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployGoerli.s.sol
+++ b/script/DeployGoerli.s.sol
@@ -14,9 +14,10 @@ contract DeployGoerli is DeployBase {
     // our test issuer
     address private immutable issuerWallet = 0xC0A00c8c9EF6fe6F0a79B8a616183384dbaf8EC8;
 
+    uint256 private immutable tokenId = 1;
     uint256 private immutable cooldown = 30 minutes;
 
-    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, cooldown) 
+    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId, cooldown) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployLocal.s.sol
+++ b/script/DeployLocal.s.sol
@@ -15,22 +15,8 @@ contract DeployLocal is DeployBase {
     address public immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
 
     uint256 public immutable cooldown = 2 minutes;
-    uint256 public immutable auctionMinimumDuration = 2 minutes;
-    uint256 public immutable auctionBidExtension = 30 seconds;
-    uint256 private immutable auctionStartingPrice = 0.1 ether;
-    uint256 private immutable auctionMinimumBidStep = 0.1 ether;
 
-    constructor()
-        DeployBase(
-            contributorWallets,
-            contributorShares,
-            issuerWallet,
-            cooldown,
-            auctionMinimumDuration,
-            auctionBidExtension,
-            auctionStartingPrice,
-            auctionMinimumBidStep
-        )
+    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, cooldown) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployLocal.s.sol
+++ b/script/DeployLocal.s.sol
@@ -12,10 +12,10 @@ contract DeployLocal is DeployBase {
     uint256[] public contributorShares = [65, 20, 15];
 
     // would be ercwl.eth for mainnet
-    address public immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
+    address public immutable creatorAddress = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
     uint256 private immutable tokenId = 1;
 
-    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId) 
+    constructor() DeployBase(contributorWallets, contributorShares, creatorAddress, tokenId) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployLocal.s.sol
+++ b/script/DeployLocal.s.sol
@@ -19,7 +19,7 @@ contract DeployLocal is DeployBase {
     uint256 public immutable auctionMinimumDuration = 2 minutes;
     uint256 public immutable auctionBidExtension = 30 seconds;
     uint256 private immutable holderTaxNumerator = 1000;
-    uint256 private immutable saleRoyaltiesNumerator = 1000;
+    uint256 private immutable royaltyNumerator = 1000;
     uint256 private immutable auctionStartingPrice = 0.1 ether;
     uint256 private immutable auctionMinimumBidStep = 0.1 ether;
 
@@ -33,9 +33,11 @@ contract DeployLocal is DeployBase {
             auctionMinimumDuration,
             auctionBidExtension,
             holderTaxNumerator,
-            saleRoyaltiesNumerator,
+            royaltyNumerator,
             auctionStartingPrice,
             auctionMinimumBidStep
         )
+    /* solhint-disable no-empty-blocks */
     {}
+    /* solhint-enable no-empty-blocks */
 }

--- a/script/DeployLocal.s.sol
+++ b/script/DeployLocal.s.sol
@@ -15,7 +15,6 @@ contract DeployLocal is DeployBase {
     address public immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
 
     uint256 public immutable cooldown = 2 minutes;
-    uint256 public immutable responseFlaggingPeriod = 2 minutes;
     uint256 public immutable auctionMinimumDuration = 2 minutes;
     uint256 public immutable auctionBidExtension = 30 seconds;
     uint256 private immutable holderTaxNumerator = 1000;
@@ -29,7 +28,6 @@ contract DeployLocal is DeployBase {
             contributorShares,
             issuerWallet,
             cooldown,
-            responseFlaggingPeriod,
             auctionMinimumDuration,
             auctionBidExtension,
             holderTaxNumerator,

--- a/script/DeployLocal.s.sol
+++ b/script/DeployLocal.s.sol
@@ -17,8 +17,6 @@ contract DeployLocal is DeployBase {
     uint256 public immutable cooldown = 2 minutes;
     uint256 public immutable auctionMinimumDuration = 2 minutes;
     uint256 public immutable auctionBidExtension = 30 seconds;
-    uint256 private immutable holderTaxNumerator = 1000;
-    uint256 private immutable royaltyNumerator = 1000;
     uint256 private immutable auctionStartingPrice = 0.1 ether;
     uint256 private immutable auctionMinimumBidStep = 0.1 ether;
 
@@ -30,8 +28,6 @@ contract DeployLocal is DeployBase {
             cooldown,
             auctionMinimumDuration,
             auctionBidExtension,
-            holderTaxNumerator,
-            royaltyNumerator,
             auctionStartingPrice,
             auctionMinimumBidStep
         )

--- a/script/DeployLocal.s.sol
+++ b/script/DeployLocal.s.sol
@@ -13,11 +13,9 @@ contract DeployLocal is DeployBase {
 
     // would be ercwl.eth for mainnet
     address public immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
-
     uint256 private immutable tokenId = 1;
-    uint256 public immutable cooldown = 2 minutes;
 
-    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId, cooldown) 
+    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployLocal.s.sol
+++ b/script/DeployLocal.s.sol
@@ -4,18 +4,18 @@ pragma solidity ^0.8.17;
 import {DeployBase} from "./DeployBase.s.sol";
 
 contract DeployLocal is DeployBase {
-    address[] public contributorWallets = [
+    address[] public beneficiaryAddresses = [
         0xE48C655276C23F1534AE2a87A2bf8A8A6585Df70, // ercwl.eth
         0x9F49230672c52A2b958F253134BB17Ac84d30833, // jonas.eth
         0xf374CE39E4dB1697c8D0D77F91A9234b2Fd55F62 // odysseas
     ];
-    uint256[] public contributorShares = [65, 20, 15];
+    uint256[] public beneficiaryShares = [65, 20, 15];
 
     // would be ercwl.eth for mainnet
     address public immutable creatorAddress = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
     uint256 private immutable tokenId = 1;
 
-    constructor() DeployBase(contributorWallets, contributorShares, creatorAddress, tokenId) 
+    constructor() DeployBase(beneficiaryAddresses, beneficiaryShares, creatorAddress, tokenId) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployLocal.s.sol
+++ b/script/DeployLocal.s.sol
@@ -14,9 +14,10 @@ contract DeployLocal is DeployBase {
     // would be ercwl.eth for mainnet
     address public immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
 
+    uint256 private immutable tokenId = 1;
     uint256 public immutable cooldown = 2 minutes;
 
-    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, cooldown) 
+    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId, cooldown) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployMainnnet.s.sol
+++ b/script/DeployMainnnet.s.sol
@@ -17,8 +17,6 @@ contract DeployMainnet is DeployBase {
     uint256 private immutable cooldown = 2 minutes;
     uint256 private immutable auctionMinimumDuration = 2 minutes;
     uint256 private immutable auctionBidExtension = 30 seconds;
-    uint256 private immutable holderTaxNumerator = 1000;
-    uint256 private immutable royaltyNumerator = 1000;
     uint256 private immutable auctionStartingPrice = 0.1 ether;
     uint256 private immutable auctionMinimumBidStep = 0.1 ether;
 
@@ -30,8 +28,6 @@ contract DeployMainnet is DeployBase {
             cooldown,
             auctionMinimumDuration,
             auctionBidExtension,
-            holderTaxNumerator,
-            royaltyNumerator,
             auctionStartingPrice,
             auctionMinimumBidStep
         )

--- a/script/DeployMainnnet.s.sol
+++ b/script/DeployMainnnet.s.sol
@@ -15,22 +15,8 @@ contract DeployMainnet is DeployBase {
     address private immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
 
     uint256 private immutable cooldown = 2 minutes;
-    uint256 private immutable auctionMinimumDuration = 2 minutes;
-    uint256 private immutable auctionBidExtension = 30 seconds;
-    uint256 private immutable auctionStartingPrice = 0.1 ether;
-    uint256 private immutable auctionMinimumBidStep = 0.1 ether;
 
-    constructor()
-        DeployBase(
-            contributorWallets,
-            contributorShares,
-            issuerWallet,
-            cooldown,
-            auctionMinimumDuration,
-            auctionBidExtension,
-            auctionStartingPrice,
-            auctionMinimumBidStep
-        )
+    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, cooldown) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployMainnnet.s.sol
+++ b/script/DeployMainnnet.s.sol
@@ -13,11 +13,9 @@ contract DeployMainnet is DeployBase {
 
     // would be ercwl.eth for mainnet
     address private immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
-
     uint256 private immutable tokenId = 1;
-    uint256 private immutable cooldown = 2 minutes;
 
-    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId, cooldown) 
+    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployMainnnet.s.sol
+++ b/script/DeployMainnnet.s.sol
@@ -4,18 +4,18 @@ pragma solidity ^0.8.17;
 import {DeployBase} from "./DeployBase.s.sol";
 
 contract DeployMainnet is DeployBase {
-    address[] private contributorWallets = [
+    address[] private beneficiaryAddresses = [
         0xE48C655276C23F1534AE2a87A2bf8A8A6585Df70, // ercwl.eth
         0x9F49230672c52A2b958F253134BB17Ac84d30833, // jonas.eth
         0xf374CE39E4dB1697c8D0D77F91A9234b2Fd55F62 // odysseas
     ];
-    uint256[] private contributorShares = [65, 20, 15];
+    uint256[] private beneficiaryShares = [65, 20, 15];
 
     // would be ercwl.eth for mainnet
     address private immutable creatorAddress = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
     uint256 private immutable tokenId = 1;
 
-    constructor() DeployBase(contributorWallets, contributorShares, creatorAddress, tokenId) 
+    constructor() DeployBase(beneficiaryAddresses, beneficiaryShares, creatorAddress, tokenId) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployMainnnet.s.sol
+++ b/script/DeployMainnnet.s.sol
@@ -12,10 +12,10 @@ contract DeployMainnet is DeployBase {
     uint256[] private contributorShares = [65, 20, 15];
 
     // would be ercwl.eth for mainnet
-    address private immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
+    address private immutable creatorAddress = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
     uint256 private immutable tokenId = 1;
 
-    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId) 
+    constructor() DeployBase(contributorWallets, contributorShares, creatorAddress, tokenId) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeployMainnnet.s.sol
+++ b/script/DeployMainnnet.s.sol
@@ -19,7 +19,7 @@ contract DeployMainnet is DeployBase {
     uint256 private immutable auctionMinimumDuration = 2 minutes;
     uint256 private immutable auctionBidExtension = 30 seconds;
     uint256 private immutable holderTaxNumerator = 1000;
-    uint256 private immutable saleRoyaltiesNumerator = 1000;
+    uint256 private immutable royaltyNumerator = 1000;
     uint256 private immutable auctionStartingPrice = 0.1 ether;
     uint256 private immutable auctionMinimumBidStep = 0.1 ether;
 
@@ -33,9 +33,11 @@ contract DeployMainnet is DeployBase {
             auctionMinimumDuration,
             auctionBidExtension,
             holderTaxNumerator,
-            saleRoyaltiesNumerator,
+            royaltyNumerator,
             auctionStartingPrice,
             auctionMinimumBidStep
         )
+    /* solhint-disable no-empty-blocks */
     {}
+    /* solhint-enable no-empty-blocks */
 }

--- a/script/DeployMainnnet.s.sol
+++ b/script/DeployMainnnet.s.sol
@@ -15,7 +15,6 @@ contract DeployMainnet is DeployBase {
     address private immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
 
     uint256 private immutable cooldown = 2 minutes;
-    uint256 private immutable responseFlaggingPeriod = 2 minutes;
     uint256 private immutable auctionMinimumDuration = 2 minutes;
     uint256 private immutable auctionBidExtension = 30 seconds;
     uint256 private immutable holderTaxNumerator = 1000;
@@ -29,7 +28,6 @@ contract DeployMainnet is DeployBase {
             contributorShares,
             issuerWallet,
             cooldown,
-            responseFlaggingPeriod,
             auctionMinimumDuration,
             auctionBidExtension,
             holderTaxNumerator,

--- a/script/DeployMainnnet.s.sol
+++ b/script/DeployMainnnet.s.sol
@@ -14,9 +14,10 @@ contract DeployMainnet is DeployBase {
     // would be ercwl.eth for mainnet
     address private immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
 
+    uint256 private immutable tokenId = 1;
     uint256 private immutable cooldown = 2 minutes;
 
-    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, cooldown) 
+    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId, cooldown) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeploySepolia.s.sol
+++ b/script/DeploySepolia.s.sol
@@ -19,7 +19,7 @@ contract DeploySepolia is DeployBase {
     uint256 private immutable auctionMinimumDuration = 2 minutes;
     uint256 private immutable auctionBidExtension = 30 seconds;
     uint256 private immutable holderTaxNumerator = 1000;
-    uint256 private immutable saleRoyaltiesNumerator = 1000;
+    uint256 private immutable royaltyNumerator = 1000;
     uint256 private immutable auctionStartingPrice = 0.1 ether;
     uint256 private immutable auctionMinimumBidStep = 0.1 ether;
 
@@ -33,9 +33,11 @@ contract DeploySepolia is DeployBase {
             auctionMinimumDuration,
             auctionBidExtension,
             holderTaxNumerator,
-            saleRoyaltiesNumerator,
+            royaltyNumerator,
             auctionStartingPrice,
             auctionMinimumBidStep
         )
+    /* solhint-disable no-empty-blocks */
     {}
+    /* solhint-enable no-empty-blocks */
 }

--- a/script/DeploySepolia.s.sol
+++ b/script/DeploySepolia.s.sol
@@ -13,11 +13,9 @@ contract DeploySepolia is DeployBase {
 
     // would be ercwl.eth for mainnet
     address private immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
-
     uint256 private immutable tokenId = 1;
-    uint256 private immutable cooldown = 2 minutes;
 
-    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId, cooldown) 
+    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeploySepolia.s.sol
+++ b/script/DeploySepolia.s.sol
@@ -15,7 +15,6 @@ contract DeploySepolia is DeployBase {
     address private immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
 
     uint256 private immutable cooldown = 2 minutes;
-    uint256 private immutable responseFlaggingPeriod = 2 minutes;
     uint256 private immutable auctionMinimumDuration = 2 minutes;
     uint256 private immutable auctionBidExtension = 30 seconds;
     uint256 private immutable holderTaxNumerator = 1000;
@@ -29,7 +28,6 @@ contract DeploySepolia is DeployBase {
             contributorShares,
             issuerWallet,
             cooldown,
-            responseFlaggingPeriod,
             auctionMinimumDuration,
             auctionBidExtension,
             holderTaxNumerator,

--- a/script/DeploySepolia.s.sol
+++ b/script/DeploySepolia.s.sol
@@ -17,8 +17,6 @@ contract DeploySepolia is DeployBase {
     uint256 private immutable cooldown = 2 minutes;
     uint256 private immutable auctionMinimumDuration = 2 minutes;
     uint256 private immutable auctionBidExtension = 30 seconds;
-    uint256 private immutable holderTaxNumerator = 1000;
-    uint256 private immutable royaltyNumerator = 1000;
     uint256 private immutable auctionStartingPrice = 0.1 ether;
     uint256 private immutable auctionMinimumBidStep = 0.1 ether;
 
@@ -30,8 +28,6 @@ contract DeploySepolia is DeployBase {
             cooldown,
             auctionMinimumDuration,
             auctionBidExtension,
-            holderTaxNumerator,
-            royaltyNumerator,
             auctionStartingPrice,
             auctionMinimumBidStep
         )

--- a/script/DeploySepolia.s.sol
+++ b/script/DeploySepolia.s.sol
@@ -12,10 +12,10 @@ contract DeploySepolia is DeployBase {
     uint256[] private contributorShares = [65, 20, 15];
 
     // would be ercwl.eth for mainnet
-    address private immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
+    address private immutable creatorAddress = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
     uint256 private immutable tokenId = 1;
 
-    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId) 
+    constructor() DeployBase(contributorWallets, contributorShares, creatorAddress, tokenId) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeploySepolia.s.sol
+++ b/script/DeploySepolia.s.sol
@@ -15,22 +15,8 @@ contract DeploySepolia is DeployBase {
     address private immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
 
     uint256 private immutable cooldown = 2 minutes;
-    uint256 private immutable auctionMinimumDuration = 2 minutes;
-    uint256 private immutable auctionBidExtension = 30 seconds;
-    uint256 private immutable auctionStartingPrice = 0.1 ether;
-    uint256 private immutable auctionMinimumBidStep = 0.1 ether;
 
-    constructor()
-        DeployBase(
-            contributorWallets,
-            contributorShares,
-            issuerWallet,
-            cooldown,
-            auctionMinimumDuration,
-            auctionBidExtension,
-            auctionStartingPrice,
-            auctionMinimumBidStep
-        )
+    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, cooldown) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeploySepolia.s.sol
+++ b/script/DeploySepolia.s.sol
@@ -4,18 +4,18 @@ pragma solidity ^0.8.17;
 import {DeployBase} from "./DeployBase.s.sol";
 
 contract DeploySepolia is DeployBase {
-    address[] private contributorWallets = [
+    address[] private beneficiaryAddresses = [
         0xE48C655276C23F1534AE2a87A2bf8A8A6585Df70, // ercwl.eth
         0x9F49230672c52A2b958F253134BB17Ac84d30833, // jonas.eth
         0xf374CE39E4dB1697c8D0D77F91A9234b2Fd55F62 // odysseas
     ];
-    uint256[] private contributorShares = [65, 20, 15];
+    uint256[] private beneficiaryShares = [65, 20, 15];
 
     // would be ercwl.eth for mainnet
     address private immutable creatorAddress = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
     uint256 private immutable tokenId = 1;
 
-    constructor() DeployBase(contributorWallets, contributorShares, creatorAddress, tokenId) 
+    constructor() DeployBase(beneficiaryAddresses, beneficiaryShares, creatorAddress, tokenId) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/script/DeploySepolia.s.sol
+++ b/script/DeploySepolia.s.sol
@@ -14,9 +14,10 @@ contract DeploySepolia is DeployBase {
     // would be ercwl.eth for mainnet
     address private immutable issuerWallet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
 
+    uint256 private immutable tokenId = 1;
     uint256 private immutable cooldown = 2 minutes;
 
-    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, cooldown) 
+    constructor() DeployBase(contributorWallets, contributorShares, issuerWallet, tokenId, cooldown) 
     /* solhint-disable no-empty-blocks */
     {}
     /* solhint-enable no-empty-blocks */

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -851,7 +851,7 @@ contract Orb is ERC721, Ownable {
      * @notice  Triggers the orb (otherwise known as Orb Invocation). Allows the holder to submit cleartext.
      * @param   cleartext  Required cleartext.
      */
-    function triggerWithCleartext(string memory cleartext) external {
+    function invokeWithCleartext(string memory cleartext) external {
         uint256 length = bytes(cleartext).length;
         if (length > CLEARTEXT_MAXIMUM_LENGTH) {
             revert CleartextTooLong(length, CLEARTEXT_MAXIMUM_LENGTH);

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -128,10 +128,9 @@ contract Orb is ERC721, Ownable {
     // Beneficiary receives all Orb proceeds.
     address public immutable beneficiary;
 
-    // Public Constants
-
     // Fee Nominator: basis points. Other fees are in relation to this.
-    uint256 public constant FEE_DENOMINATOR = 10000;
+    uint256 public constant FEE_DENOMINATOR = 10_000;
+
     // Harberger Tax for holding.
     uint256 public immutable holderTaxNumerator;
     // Harberger Tax period: for how long the Tax Rate applies. Value: 1 year.

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -951,29 +951,29 @@ contract Orb is ERC721, Ownable {
      *          Also, the holder must have received the orb after the response was made;
      *          this is to prevent holders from flagging responses that were made in response to others' triggers.
      *          Emits ResponseFlagging().
-     * @param   triggerId  ID of a trigger to which the response is being flagged.
+     * @param   invocationId  ID of a trigger to which the response is being flagged.
      */
-    function flagResponse(uint256 triggerId) external onlyHolder onlyHolderSolvent {
-        if (!_responseExists(triggerId)) {
-            revert ResponseNotFound(triggerId);
+    function flagResponse(uint256 invocationId) external onlyHolder onlyHolderSolvent {
+        if (!_responseExists(invocationId)) {
+            revert ResponseNotFound(invocationId);
         }
 
         // Response Flagging Period starts counting from when the response is made.
-        uint256 responseTime = responses[triggerId].timestamp;
+        uint256 responseTime = responses[invocationId].timestamp;
         if (block.timestamp - responseTime > responseFlaggingPeriod) {
-            revert FlaggingPeriodExpired(triggerId, block.timestamp - responseTime, responseFlaggingPeriod);
+            revert FlaggingPeriodExpired(invocationId, block.timestamp - responseTime, responseFlaggingPeriod);
         }
         if (holderReceiveTime >= responseTime) {
-            revert FlaggingPeriodExpired(triggerId, holderReceiveTime, responseTime);
+            revert FlaggingPeriodExpired(invocationId, holderReceiveTime, responseTime);
         }
-        if (responseFlagged[triggerId]) {
-            revert ResponseAlreadyFlagged(triggerId);
+        if (responseFlagged[invocationId]) {
+            revert ResponseAlreadyFlagged(invocationId);
         }
 
-        responseFlagged[triggerId] = true;
+        responseFlagged[invocationId] = true;
         flaggedResponsesCount += 1;
 
-        emit ResponseFlagging(msg.sender, triggerId);
+        emit ResponseFlagging(msg.sender, invocationId);
     }
 
     /**

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -76,7 +76,7 @@ contract Orb is ERC721, Ownable {
     // Triggering and Responding Events
     event Invocation(address indexed invoker, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
     event Response(address indexed responder, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
-    event CleartextRecorded(uint256 indexed triggerId, string cleartext);
+    event CleartextRecorded(uint256 indexed invocationId, string cleartext);
     event ResponseFlagged(address indexed from, uint256 indexed responseId);
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -134,7 +134,7 @@ contract Orb is ERC721, Ownable {
     // Response Flagging Period: how long after resonse was recorded it can be flagged by the holder.
     uint256 public immutable responseFlaggingPeriod;
     // Maximum length for trigger cleartext content.
-    uint256 public constant MAX_CLEARTEXT_LENGTH = 280;
+    uint256 public constant CLEARTEXT_MAXIMUM_LENGTH = 280;
 
     // Fee Nominator: basis points. Other fees are in relation to this.
     uint256 public constant FEE_DENOMINATOR = 10000;
@@ -853,8 +853,8 @@ contract Orb is ERC721, Ownable {
      */
     function triggerWithCleartext(string memory cleartext) external {
         uint256 length = bytes(cleartext).length;
-        if (length > MAX_CLEARTEXT_LENGTH) {
-            revert CleartextTooLong(length, MAX_CLEARTEXT_LENGTH);
+        if (length > CLEARTEXT_MAXIMUM_LENGTH) {
+            revert CleartextTooLong(length, CLEARTEXT_MAXIMUM_LENGTH);
         }
         emit CleartextRecorded(triggersCount, cleartext);
         triggerWithHash(keccak256(abi.encodePacked(cleartext)));
@@ -899,8 +899,8 @@ contract Orb is ERC721, Ownable {
     function recordTriggerCleartext(uint256 triggerId, string memory cleartext) external onlyHolder onlyHolderSolvent {
         uint256 cleartextLength = bytes(cleartext).length;
 
-        if (cleartextLength > MAX_CLEARTEXT_LENGTH) {
-            revert CleartextTooLong(cleartextLength, MAX_CLEARTEXT_LENGTH);
+        if (cleartextLength > CLEARTEXT_MAXIMUM_LENGTH) {
+            revert CleartextTooLong(cleartextLength, CLEARTEXT_MAXIMUM_LENGTH);
         }
 
         bytes32 recordedContentHash = triggers[triggerId];

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -74,7 +74,7 @@ contract Orb is ERC721, Ownable {
     event Foreclosure(address indexed formerHolder, bool indexed voluntary);
 
     // Triggering and Responding Events
-    event Triggered(address indexed from, uint256 indexed triggerId, bytes32 contentHash, uint256 time);
+    event Invocation(address indexed invoker, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
     event Responded(address indexed from, uint256 indexed triggerId, bytes32 contentHash, uint256 time);
     event CleartextRecorded(uint256 indexed triggerId, string cleartext);
     event ResponseFlagged(address indexed from, uint256 indexed responseId);
@@ -867,7 +867,7 @@ contract Orb is ERC721, Ownable {
      *          The Orb can only be triggered by solvent holders.
      * @dev     Content hash is keccak256 of the cleartext.
      *          invocationCount is used to track the id of the next trigger.
-     *          Emits Triggered().
+     *          Emits Invocation().
      * @param   contentHash  Required keccak256 hash of the cleartext.
      */
     function invokeWithHash(bytes32 contentHash) public onlyHolder onlyHolderHeld onlyHolderSolvent {
@@ -881,7 +881,7 @@ contract Orb is ERC721, Ownable {
         lastInvocationTime = block.timestamp;
         invocationCount += 1;
 
-        emit Triggered(msg.sender, triggerId, contentHash, block.timestamp);
+        emit Invocation(msg.sender, triggerId, contentHash, block.timestamp);
     }
 
     /**

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -800,7 +800,9 @@ contract Orb is ERC721, Ownable {
     function foreclose() external onlyHolderHeld onlyHolderInsolvent settles {
         address holder = ERC721.ownerOf(TOKEN_ID);
         price = 0;
+
         emit Foreclosure(holder, false);
+
         _transferOrb(holder, address(this));
     }
 

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -129,8 +129,6 @@ contract Orb is ERC721, Ownable {
     address public immutable beneficiary;
 
     // Public Constants
-    // Response Flagging Period: how long after resonse was recorded it can be flagged by the holder.
-    uint256 public immutable responseFlaggingPeriod;
     // Maximum length for invocation cleartext content.
     uint256 public constant CLEARTEXT_MAXIMUM_LENGTH = 280;
 
@@ -226,7 +224,6 @@ contract Orb is ERC721, Ownable {
      *       This token represents the Orb and is called the Orb elsewhere in the contract.
      *       {Ownable} sets the deployer to be the owner, and also the creator in the Orb context.
      * @param cooldown_  How often Orb can be invoked.
-     * @param responseFlaggingPeriod_  How long after resonse was recorded it can be flagged by the holder.
      * @param auctionMinimumDuration_  Minimum length for an auction.
      * @param auctionBidExtension_     If remaining time is less than this after a bid is made,
      *                                 auction will continue for at least this long.
@@ -234,7 +231,6 @@ contract Orb is ERC721, Ownable {
      */
     constructor(
         uint256 cooldown_,
-        uint256 responseFlaggingPeriod_,
         uint256 auctionMinimumDuration_,
         uint256 auctionBidExtension_,
         address beneficiary_,
@@ -244,7 +240,6 @@ contract Orb is ERC721, Ownable {
         uint256 auctionMinimumBidStep_
     ) ERC721("Orb", "ORB") {
         cooldown = cooldown_;
-        responseFlaggingPeriod = responseFlaggingPeriod_;
         auctionMinimumDuration = auctionMinimumDuration_;
         auctionBidExtension = auctionBidExtension_;
         beneficiary = beneficiary_;
@@ -960,9 +955,10 @@ contract Orb is ERC721, Ownable {
         }
 
         // Response Flagging Period starts counting from when the response is made.
+        // Its value matches the cooldown of the Orb.
         uint256 responseTime = responses[invocationId].timestamp;
-        if (block.timestamp - responseTime > responseFlaggingPeriod) {
-            revert FlaggingPeriodExpired(invocationId, block.timestamp - responseTime, responseFlaggingPeriod);
+        if (block.timestamp - responseTime > cooldown) {
+            revert FlaggingPeriodExpired(invocationId, block.timestamp - responseTime, cooldown);
         }
         if (holderReceiveTime >= responseTime) {
             revert FlaggingPeriodExpired(invocationId, holderReceiveTime, responseTime);

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -112,7 +112,7 @@ contract Orb is ERC721, Ownable {
     // Triggering and Responding Errors
     error CooldownIncomplete(uint256 timeRemaining);
     error CleartextTooLong(uint256 cleartextLength, uint256 cleartextMaximumLength);
-    error CleartextHashMismatch(bytes32 cleartextHash, bytes32 contentHash);
+    error CleartextHashMismatch(bytes32 cleartextHash, bytes32 recordedContentHash);
     error TriggerNotFound(uint256 triggerId);
     error ResponseNotFound(uint256 triggerId);
     error ResponseExists(uint256 triggerId);

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -206,7 +206,7 @@ contract Orb is ERC721, Ownable {
     // Last Trigger Time: when the orb was last triggered. Used together with Cooldown constant.
     uint256 public lastInvocationTime;
     // Mapping for Triggers (Orb Invocations): triggerId to contentHash (bytes32).
-    mapping(uint256 => bytes32) public triggers;
+    mapping(uint256 => bytes32) public invocations;
     // Count of triggers made. Used to calculate triggerId of the next trigger.
     uint256 public invocationCount = 0;
     // Mapping for Responses (Replies to Triggers): matching triggerId to HashTime struct.
@@ -877,7 +877,7 @@ contract Orb is ERC721, Ownable {
 
         uint256 triggerId = invocationCount;
 
-        triggers[triggerId] = contentHash;
+        invocations[triggerId] = contentHash;
         lastInvocationTime = block.timestamp;
         invocationCount += 1;
 
@@ -907,7 +907,7 @@ contract Orb is ERC721, Ownable {
             revert CleartextTooLong(cleartextLength, CLEARTEXT_MAXIMUM_LENGTH);
         }
 
-        bytes32 recordedContentHash = triggers[triggerId];
+        bytes32 recordedContentHash = invocations[triggerId];
         bytes32 cleartextHash = keccak256(abi.encodePacked(cleartext));
 
         if (recordedContentHash != cleartextHash) {

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -62,7 +62,7 @@ contract Orb is ERC721, Ownable {
     // Auction Events
     event AuctionStart(uint256 auctionStartTime, uint256 auctionEndTime);
     event AuctionBid(address indexed bidder, uint256 bid);
-    event AuctionExtended(uint256 newAuctionEndTime);
+    event AuctionExtension(uint256 newAuctionEndTime);
     event AuctionFinalized(address indexed winner, uint256 winningBid);
 
     // Fund Management, Holding and Purchasing Events
@@ -503,7 +503,7 @@ contract Orb is ERC721, Ownable {
 
         if (block.timestamp + auctionBidExtension > auctionEndTime) {
             auctionEndTime = block.timestamp + auctionBidExtension;
-            emit AuctionExtended(auctionEndTime);
+            emit AuctionExtension(auctionEndTime);
         }
     }
 

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -62,7 +62,7 @@ contract Orb is ERC721, Ownable {
     // Auction Events
     event AuctionStarted(uint256 auctionStartTime, uint256 auctionEndTime);
     event AuctionBid(address indexed bidder, uint256 bid);
-    event UpdatedAuctionEnd(uint256 auctionEndTime);
+    event AuctionExtended(uint256 newAuctionEndTime);
     event AuctionFinalized(address indexed winner, uint256 price);
 
     // Fund Management, Holding and Purchasing Events
@@ -503,7 +503,7 @@ contract Orb is ERC721, Ownable {
 
         if (block.timestamp + auctionBidExtension > auctionEndTime) {
             auctionEndTime = block.timestamp + auctionBidExtension;
-            emit UpdatedAuctionEnd(auctionEndTime);
+            emit AuctionExtended(auctionEndTime);
         }
     }
 

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -978,11 +978,11 @@ contract Orb is ERC721, Ownable {
 
     /**
      * @dev     Returns if a response to a trigger exists, based on the timestamp of the response being non-zero.
-     * @param   triggerId_  ID of a trigger to which to check the existance of a response of.
+     * @param   invocationId_  ID of a trigger to which to check the existance of a response of.
      * @return  bool  If a response to a trigger exists or not.
      */
-    function _responseExists(uint256 triggerId_) internal view returns (bool) {
-        if (responses[triggerId_].timestamp != 0) {
+    function _responseExists(uint256 invocationId_) internal view returns (bool) {
+        if (responses[invocationId_].timestamp != 0) {
             return true;
         }
         return false;

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -129,8 +129,6 @@ contract Orb is ERC721, Ownable {
     address public immutable beneficiary;
 
     // Public Constants
-    // Cooldown: how often Orb can be invoked.
-    uint256 public immutable cooldown;
     // Response Flagging Period: how long after resonse was recorded it can be flagged by the holder.
     uint256 public immutable responseFlaggingPeriod;
     // Maximum length for invocation cleartext content.
@@ -165,6 +163,9 @@ contract Orb is ERC721, Ownable {
     uint256 internal constant MAX_PRICE = 2 ** 128;
 
     // STATE
+
+    // Cooldown: how often Orb can be invoked.
+    uint256 public cooldown;
 
     // Funds tracker, per address. Modified by deposits, withdrawals and settlements.
     // The value is without settlement. It means effective user funds (withdrawable) would be different

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -70,7 +70,7 @@ contract Orb is ERC721, Ownable {
     event Withdrawal(address indexed recipient, uint256 amount);
     event Settlement(address indexed holder, address indexed beneficiary, uint256 amount);
     event PriceUpdated(uint256 previousPrice, uint256 newPrice);
-    event Purchase(address indexed from, address indexed to, uint256 price);
+    event Purchase(address indexed seller, address indexed buyer, uint256 price);
     event Foreclosure(address indexed from, bool indexed voluntary);
 
     // Triggering and Responding Events

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -68,7 +68,7 @@ contract Orb is ERC721, Ownable {
     // Fund Management, Holding and Purchasing Events
     event Deposit(address indexed depositor, uint256 amount);
     event Withdrawal(address indexed recipient, uint256 amount);
-    event Settlement(address indexed from, address indexed to, uint256 amount);
+    event Settlement(address indexed holder, address indexed beneficiary, uint256 amount);
     event NewPrice(uint256 from, uint256 to);
     event Purchase(address indexed from, address indexed to, uint256 price);
     event Foreclosure(address indexed from, bool indexed voluntary);

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -116,7 +116,7 @@ contract Orb is ERC721, Ownable {
     error InvocationNotFound(uint256 invocationId);
     error ResponseNotFound(uint256 invocationId);
     error ResponseExists(uint256 invocationId);
-    error FlaggingPeriodExpired(uint256 triggerId, uint256 currentTimeValue, uint256 timeValueLimit);
+    error FlaggingPeriodExpired(uint256 invocationId, uint256 currentTimeValue, uint256 timeValueLimit);
     error ResponseAlreadyFlagged(uint256 triggerId);
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -131,8 +131,6 @@ contract Orb is ERC721, Ownable {
     // Fee Nominator: basis points. Other fees are in relation to this.
     uint256 public constant FEE_DENOMINATOR = 10_000;
 
-    // Harberger Tax for holding.
-    uint256 public immutable holderTaxNumerator;
     // Harberger Tax period: for how long the Tax Rate applies. Value: 1 year.
     uint256 public constant HOLDER_TAX_PERIOD = 365 days;
     // Secondary sale royalty paid to beneficiary, based on sale price.
@@ -172,6 +170,8 @@ contract Orb is ERC721, Ownable {
     // Last time Orb holder's funds were settled.
     // Shouldn't be useful if the Orb is held by the contract.
     uint256 public lastSettlementTime;
+    // Harberger Tax for holding. Initial value is 10%.
+    uint256 public holderTaxNumerator = 1_000;
 
     // Auction State Variables
     // Start Time: when the auction was started. Stays fixed during the auction, otherwise 0.

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -61,7 +61,7 @@ contract Orb is ERC721, Ownable {
 
     // Auction Events
     event AuctionStarted(uint256 auctionStartTime, uint256 auctionEndTime);
-    event NewBid(address indexed from, uint256 price);
+    event AuctionBid(address indexed bidder, uint256 bid);
     event UpdatedAuctionEnd(uint256 auctionEndTime);
     event AuctionFinalized(address indexed winner, uint256 price);
 
@@ -471,7 +471,7 @@ contract Orb is ERC721, Ownable {
      * @notice  Bids the provided amount, if there's enough funds across funds on contract and transaction value.
      *          Might extend the auction if the bid is near the end.
      *          Important: the winning bidder will not be able to withdraw funds until someone outbids them.
-     * @dev     Emits NewBid().
+     * @dev     Emits AuctionBid().
      * @param   amount  The value to bid.
      * @param   priceIfWon  Price if the bid wins. Must be less than MAX_PRICE.
      */
@@ -499,7 +499,7 @@ contract Orb is ERC721, Ownable {
         leadingBid = amount;
         price = priceIfWon;
 
-        emit NewBid(msg.sender, amount);
+        emit AuctionBid(msg.sender, amount);
 
         if (block.timestamp + auctionBidExtension > auctionEndTime) {
             auctionEndTime = block.timestamp + auctionBidExtension;

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -895,10 +895,10 @@ contract Orb is ERC721, Ownable {
      *          If the content hash is of a cleartext that is longer than maximum cleartext length, the contract will
      *          never record this cleartext, as it is invalid.
      *          Allows overwriting. Assuming no hash collisions, this poses no risk, just wastes holder gas.
-     * @param   triggerId  Triggred id, matching the one that was emitted when calling {trigger()}.
+     * @param   invocationId  Triggred id, matching the one that was emitted when calling {trigger()}.
      * @param   cleartext  Cleartext, limited in length. Must match the content hash.
      */
-    function recordInvocationCleartext(uint256 triggerId, string memory cleartext)
+    function recordInvocationCleartext(uint256 invocationId, string memory cleartext)
         external
         onlyHolder
         onlyHolderSolvent
@@ -909,14 +909,14 @@ contract Orb is ERC721, Ownable {
             revert CleartextTooLong(cleartextLength, CLEARTEXT_MAXIMUM_LENGTH);
         }
 
-        bytes32 recordedContentHash = invocations[triggerId];
+        bytes32 recordedContentHash = invocations[invocationId];
         bytes32 cleartextHash = keccak256(abi.encodePacked(cleartext));
 
         if (recordedContentHash != cleartextHash) {
             revert CleartextHashMismatch(cleartextHash, recordedContentHash);
         }
 
-        emit CleartextRecording(triggerId, cleartext);
+        emit CleartextRecording(invocationId, cleartext);
     }
 
     /**

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -324,8 +324,8 @@ contract Orb is ERC721, Ownable {
     }
 
     /**
-     * @dev  Ensures that the caller is not currently winning the auction.
-     *       User winning the auction cannot withdraw funds, as funds include user's bid.
+     * @dev  Ensures that the caller is not currently leading the auction.
+     *       User leading the auction cannot withdraw funds, as funds include user's bid.
      */
     modifier notLeadingBidder() {
         if (msg.sender == leadingBidder) {
@@ -470,7 +470,7 @@ contract Orb is ERC721, Ownable {
     /**
      * @notice  Bids the provided amount, if there's enough funds across funds on contract and transaction value.
      *          Might extend the auction if the bid is near the end.
-     *          Important: the winning bidder will not be able to withdraw funds until someone outbids them.
+     *          Important: the leading bidder will not be able to withdraw funds until someone outbids them.
      * @dev     Emits AuctionBid().
      * @param   amount      The value to bid.
      * @param   priceIfWon  Price if the bid wins. Must be less than MAX_PRICE.
@@ -566,7 +566,7 @@ contract Orb is ERC721, Ownable {
     /**
      * @notice  Function to withdraw all funds on the contract.
      *          Not recommended for current Orb holders, they should call relinquish() to take out their funds.
-     * @dev     Not allowed for the winning auction bidder.
+     * @dev     Not allowed for the leading auction bidder.
      */
     function withdrawAll() external notLeadingBidder settlesIfHolder {
         _withdraw(msg.sender, fundsOf[msg.sender]);
@@ -575,7 +575,7 @@ contract Orb is ERC721, Ownable {
     /**
      * @notice  Function to withdraw given amount from the contract.
      *          For current Orb holders, reduces the time until foreclosure.
-     * @dev     Not allowed for the winning auction bidder.
+     * @dev     Not allowed for the leading auction bidder.
      */
     function withdraw(uint256 amount) external notLeadingBidder settlesIfHolder {
         _withdraw(msg.sender, amount);

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -924,21 +924,21 @@ contract Orb is ERC721, Ownable {
      *          it was made. A response to a trigger can only be written once. There is no way to record response
      *          cleartext on-chain.
      * @dev     Emits Response().
-     * @param   triggerId  ID of a trigger to which the response is being made.
+     * @param   invocationId  ID of a trigger to which the response is being made.
      * @param   contentHash  keccak256 hash of the response text.
      */
-    function respond(uint256 triggerId, bytes32 contentHash) external onlyOwner {
-        if (triggerId >= invocationCount) {
-            revert InvocationNotFound(triggerId);
+    function respond(uint256 invocationId, bytes32 contentHash) external onlyOwner {
+        if (invocationId >= invocationCount) {
+            revert InvocationNotFound(invocationId);
         }
 
-        if (_responseExists(triggerId)) {
-            revert ResponseExists(triggerId);
+        if (_responseExists(invocationId)) {
+            revert ResponseExists(invocationId);
         }
 
-        responses[triggerId] = HashTime(contentHash, block.timestamp);
+        responses[invocationId] = HashTime(contentHash, block.timestamp);
 
-        emit Response(msg.sender, triggerId, contentHash, block.timestamp);
+        emit Response(msg.sender, invocationId, contentHash, block.timestamp);
     }
 
     /**

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -161,7 +161,7 @@ contract Orb is ERC721, Ownable {
     string internal constant BASE_URL = "https://static.orb.land/orb/";
     // Special value returned when foreclosure time is "never".
     uint256 internal constant INFINITY = type(uint256).max;
-    // Maximum orb price, limited to prevent potential overflows.
+    // Maximum Orb price, limited to prevent potential overflows.
     uint256 internal constant MAX_PRICE = 2 ** 128;
 
     // STATE
@@ -174,10 +174,10 @@ contract Orb is ERC721, Ownable {
 
     // Price of the Orb. No need for mapping, as only one token is ever minted.
     // Also used during auction to store future purchase price.
-    // Shouldn't be useful is orb is held by the contract.
+    // Shouldn't be useful if the Orb is held by the contract.
     uint256 public price;
-    // Last time orb holder's funds were settled.
-    // Shouldn't be useful is orb is held by the contract.
+    // Last time Orb holder's funds were settled.
+    // Shouldn't be useful if the Orb is held by the contract.
     uint256 public lastSettlementTime;
 
     // Auction State Variables
@@ -201,9 +201,9 @@ contract Orb is ERC721, Ownable {
         uint256 timestamp;
     }
 
-    // Holder Receive Time: When the orb was last transferred, except to this contract.
+    // Holder Receive Time: When the Orb was last transferred, except to this contract.
     uint256 public holderReceiveTime;
-    // Last Invocation Time: when the orb was last invoked. Used together with Cooldown constant.
+    // Last Invocation Time: when the Orb was last invoked. Used together with Cooldown constant.
     uint256 public lastInvocationTime;
     // Mapping for Invocation: invocationId to contentHash (bytes32).
     mapping(uint256 => bytes32) public invocations;
@@ -223,7 +223,7 @@ contract Orb is ERC721, Ownable {
     /**
      * @dev  When deployed, contract mints the only token that will ever exist, to itself.
      *       This token represents the Orb and is called the Orb elsewhere in the contract.
-     *       {Ownable} sets the deployer to be the owner, and also the creator in the orb context.
+     *       {Ownable} sets the deployer to be the owner, and also the creator in the Orb context.
      * @param cooldown_  How often Orb can be invoked.
      * @param responseFlaggingPeriod_  How long after resonse was recorded it can be flagged by the holder.
      * @param auctionMinimumDuration_  Minimum length for an auction.
@@ -266,7 +266,7 @@ contract Orb is ERC721, Ownable {
      */
 
     /**
-     * @dev  Ensures that the caller owns the orb.
+     * @dev  Ensures that the caller owns the Orb.
      *       Should only be used in conjuction with {onlyHolderHeld} or on external functions,
      *       otherwise does not make sense.
      */
@@ -280,7 +280,7 @@ contract Orb is ERC721, Ownable {
     // ORB STATE MODIFIERS
 
     /**
-     * @dev  Ensures that the orb belongs to someone, not the contract itself.
+     * @dev  Ensures that the Orb belongs to someone, not the contract itself.
      */
     modifier onlyHolderHeld() {
         if (address(this) == ERC721.ownerOf(TOKEN_ID)) {
@@ -290,7 +290,7 @@ contract Orb is ERC721, Ownable {
     }
 
     /**
-     * @dev  Ensures that the orb belongs to the contract itself, either because it hasn't been auctioned,
+     * @dev  Ensures that the Orb belongs to the contract itself, either because it hasn't been auctioned,
      *       or because it has returned to the contract due to {relinquish()} or {foreclose()}
      */
     modifier onlyContractHeld() {
@@ -337,7 +337,7 @@ contract Orb is ERC721, Ownable {
     // FUNDS-RELATED MODIFIERS
 
     /**
-     * @dev  Ensures that the current orb holder has enough funds to cover Harberger tax until now.
+     * @dev  Ensures that the current Orb holder has enough funds to cover Harberger tax until now.
      */
     modifier onlyHolderSolvent() {
         if (!holderSolvent()) {
@@ -347,7 +347,7 @@ contract Orb is ERC721, Ownable {
     }
 
     /**
-     * @dev  Ensures that the current orb holder has run out of funds to cover Harberger tax.
+     * @dev  Ensures that the current Orb holder has run out of funds to cover Harberger tax.
      */
     modifier onlyHolderInsolvent() {
         if (holderSolvent()) {
@@ -357,7 +357,7 @@ contract Orb is ERC721, Ownable {
     }
 
     /**
-     * @dev  Modifier settles current orb holder's debt before executing the rest of the function.
+     * @dev  Modifier settles current Orb holder's debt before executing the rest of the function.
      */
     modifier settles() {
         _settle();
@@ -365,8 +365,8 @@ contract Orb is ERC721, Ownable {
     }
 
     /**
-     * @dev  Modifier settles current orb holder's debt before executing the rest of the function,
-     *       only if the caller is the orb holder. Useful for holder withdrawals.
+     * @dev  Modifier settles current Orb holder's debt before executing the rest of the function,
+     *       only if the caller is the Orb holder. Useful for holder withdrawals.
      */
     modifier settlesIfHolder() {
         if (msg.sender == ERC721.ownerOf(TOKEN_ID)) {
@@ -384,7 +384,7 @@ contract Orb is ERC721, Ownable {
     }
 
     /**
-     * @notice  Transfers the orb to another address. Not allowed, always reverts.
+     * @notice  Transfers the Orb to another address. Not allowed, always reverts.
      * @dev     Always reverts.
      */
     function transferFrom(address, address, uint256) public pure override {
@@ -508,7 +508,7 @@ contract Orb is ERC721, Ownable {
     }
 
     /**
-     * @notice  Finalizes the Auction, transferring the winning bid to the beneficiary, and the orb to the winner.
+     * @notice  Finalizes the Auction, transferring the winning bid to the beneficiary, and the Orb to the winner.
      *          Sets lastInvocationTime so that the Orb could be invoked immediately.
      *          The price has been set when bidding, now becomes relevant.
      *          If no bids were made, resets the state to allow the auction to be started again later.
@@ -551,7 +551,7 @@ contract Orb is ERC721, Ownable {
     /**
      * @notice  Allows depositing funds on the contract. Not allowed for insolvent holders.
      * @dev     Deposits are not allowed for insolvent holders to prevent cheating via front-running.
-     *          If the user becomes insolvent, the orb will always be returned to the contract as the next step.
+     *          If the user becomes insolvent, the Orb will always be returned to the contract as the next step.
      *          Emits Deposit().
      */
     function deposit() external payable {
@@ -565,7 +565,7 @@ contract Orb is ERC721, Ownable {
 
     /**
      * @notice  Function to withdraw all funds on the contract.
-     *          Not recommended for current orb holders, they should call relinquish() to take out their funds.
+     *          Not recommended for current Orb holders, they should call relinquish() to take out their funds.
      * @dev     Not allowed for the winning auction bidder.
      */
     function withdrawAll() external notLeadingBidder settlesIfHolder {
@@ -574,7 +574,7 @@ contract Orb is ERC721, Ownable {
 
     /**
      * @notice  Function to withdraw given amount from the contract.
-     *          For current orb holders, reduces the time until foreclosure.
+     *          For current Orb holders, reduces the time until foreclosure.
      * @dev     Not allowed for the winning auction bidder.
      */
     function withdraw(uint256 amount) external notLeadingBidder settlesIfHolder {
@@ -591,13 +591,13 @@ contract Orb is ERC721, Ownable {
 
     /**
      * @notice  Settlements transfer funds from Orb holder to the beneficiary.
-     *          Orb accounting minimizes required transactions: orb holder's foreclosure time is only
+     *          Orb accounting minimizes required transactions: Orb holder's foreclosure time is only
      *          dependent on the price and available funds. Fund transfers are not necessary unless
      *          these variables (price, holder funds) are being changed. Settlement transfers funds owed
      *          since the last settlement, and a new period of virtual accounting begins.
      * @dev     Holder might owe more than they have funds available: it means that the holder is foreclosable.
      *          Settlement would transfer all holder funds to the beneficiary, but not more.
-     *          Does nothing if the creator holds the Orb. Reverts if contract holds the orb.
+     *          Does nothing if the creator holds the Orb. Reverts if contract holds the Orb.
      *          Emits Settlement().
      */
     function settle() external onlyHolderHeld {
@@ -605,8 +605,8 @@ contract Orb is ERC721, Ownable {
     }
 
     /**
-     * @dev     Returns if the current orb holder has enough funds to cover Harberger tax until now.
-     *          Always true is creator holds the orb.
+     * @dev     Returns if the current Orb holder has enough funds to cover Harberger tax until now.
+     *          Always true is creator holds the Orb.
      * @return  bool  If the current holder is solvent.
      */
     function holderSolvent() public view returns (bool) {
@@ -618,11 +618,11 @@ contract Orb is ERC721, Ownable {
     }
 
     /**
-     * @dev     Calculates how much money orb holder owes orb beneficiary. This amount would be transferred between
+     * @dev     Calculates how much money Orb holder owes Orb beneficiary. This amount would be transferred between
      *          accounts during settlement.
      *          Owed amount can be higher than hodler's funds! It's important to check if holder has enough funds
      *          before transferring.
-     * @return  bool  Wei orb holders owes orb beneficiary since the last settlement time.
+     * @return  bool  Wei Orb holder owes Orb beneficiary since the last settlement time.
      */
     function _owedSinceLastSettlement() internal view returns (uint256) {
         uint256 secondsSinceLastSettlement = block.timestamp - lastSettlementTime;
@@ -659,7 +659,7 @@ contract Orb is ERC721, Ownable {
             return;
         }
 
-        // Should never be reached if this contract holds the orb.
+        // Should never be reached if this contract holds the Orb.
         assert(address(this) != holder);
 
         uint256 availableFunds = fundsOf[holder];
@@ -679,29 +679,29 @@ contract Orb is ERC721, Ownable {
     ////////////////////////////////////////////////////////////////////////////////
 
     /**
-     * @notice  Sets the new purchase price for the orb. Harberger tax means the asset is always for sale.
+     * @notice  Sets the new purchase price for the Orb. Harberger tax means the asset is always for sale.
      *          The price can be set to zero, making foreclosure time to be never.
      * @dev     Can only be called by a solvent holder.
      *          Settles before adjusting the price, as the new price will change foreclosure time.
      *          Does not check if the new price differs from the previous price: no risk.
      *          Limits the price to MAX_PRICE to prevent potential overflows in math.
      *          Emits PriceUpdate().
-     * @param   newPrice  New price for the orb.
+     * @param   newPrice  New price for the Orb.
      */
     function setPrice(uint256 newPrice) external onlyHolder onlyHolderSolvent settles {
         _setPrice(newPrice);
     }
 
     /**
-     * @notice  Purchasing is the mechanism to take over the orb. With Harberger tax, an orb can always be
+     * @notice  Purchasing is the mechanism to take over the Orb. With Harberger tax, the Orb can always be
      *          purchased from its holder.
-     *          Purchasing is only allowed while the holder is solvent. If not, the orb has to be foreclosed and
+     *          Purchasing is only allowed while the holder is solvent. If not, the Orb has to be foreclosed and
      *          re-auctioned.
      *          Purchaser is required to have more funds than the price itself, but the exact amount is left for the
      *          user interface implementation to calculate and send along.
      *          Purchasing sends sale royalty part to the beneficiary.
      * @dev     Requires to provide the current price as the first parameter to prevent front-running: without current
-     *          price requirement someone could purchase the orb ahead of someone else, set the price higher, and
+     *          price requirement someone could purchase the Orb ahead of someone else, set the price higher, and
      *          profit from the purchase.
      *          Does not modify last invocation time, unlike buying from the auction.
      *          Does not allow purchasing from yourself.
@@ -776,9 +776,9 @@ contract Orb is ERC721, Ownable {
     ////////////////////////////////////////////////////////////////////////////////
 
     /**
-     * @notice  Relinquishment is a voluntary giving up of the orb. It's a combination of withdrawing all funds
+     * @notice  Relinquishment is a voluntary giving up of the Orb. It's a combination of withdrawing all funds
      *          not owed to the beneficiary since last settlement, and foreclosing yourself after.
-     *          Most useful if the creator themselves hold the orb and want to re-auction it.
+     *          Most useful if the creator themselves hold the Orb and want to re-auction it.
      *          For any other holder, setting the price to zero would be more practical.
      * @dev     Calls _withdraw(), which does value transfer from the contract.
      *          Emits Foreclosure() and Withdrawal().
@@ -793,8 +793,8 @@ contract Orb is ERC721, Ownable {
     }
 
     /**
-     * @notice  Foreclose can be called by anyone after the orb holder runs out of funds to cover the Harberger tax.
-     *          It returns the orb to the contract, readying it for re-auction.
+     * @notice  Foreclose can be called by anyone after the Orb holder runs out of funds to cover the Harberger tax.
+     *          It returns the Orb to the contract, readying it for re-auction.
      * @dev     Emits Foreclosure().
      */
     function foreclose() external onlyHolderHeld onlyHolderInsolvent settles {
@@ -809,8 +809,8 @@ contract Orb is ERC721, Ownable {
     /**
      * @notice  Foreclosure time is time when the current holder will no longer have enough funds to cover the
      *          Harberger tax and can be foreclosed.
-     * @dev     Only valid if someone, not the contract, holds the orb.
-     *          If orb is held by the creator or if the price is zero, foreclosure time is a special value INFINITY.
+     * @dev     Only valid if someone, not the contract, holds the Orb.
+     *          If the Orb is held by the creator or if the price is zero, foreclosure time is INFINITY constant.
      * @return  uint256  Timestamp of the foreclosure time.
      */
     function foreclosureTime() external view returns (uint256) {
@@ -834,11 +834,11 @@ contract Orb is ERC721, Ownable {
     ////////////////////////////////////////////////////////////////////////////////
 
     /**
-     * @notice  Time remaining until the orb can be invoked again.
-     *          Returns zero if the cooldown has expired and the orb is ready.
-     * @dev     This function is only meaningful if the orb is not held by contract, and the holder is solvent.
-     *          Contract itself cannot invoke the orb, so the response would be meaningless.
-     * @return  uint256  Time in seconds until the orb is ready to be invoked.
+     * @notice  Time remaining until the Orb can be invoked again.
+     *          Returns zero if the cooldown has expired and the Orb is ready.
+     * @dev     This function is only meaningful if the Orb is not held by contract, and the holder is solvent.
+     *          Contract itself cannot invoke the Orb, so the response would be meaningless.
+     * @return  uint256  Time in seconds until the Orb is ready to be invoked.
      */
     function cooldownRemaining() external view returns (uint256) {
         uint256 cooldownExpires = lastInvocationTime + cooldown;
@@ -850,7 +850,7 @@ contract Orb is ERC721, Ownable {
     }
 
     /**
-     * @notice  Invokes the orb (otherwise known as Orb Invocation). Allows the holder to submit cleartext.
+     * @notice  Invokes the Orb. Allows the holder to submit cleartext.
      * @param   cleartext  Required cleartext.
      */
     function invokeWithCleartext(string memory cleartext) external {
@@ -863,8 +863,8 @@ contract Orb is ERC721, Ownable {
     }
 
     /**
-     * @notice  Invokes the orb. Allows the holder to submit content hash, that represents a question to the orb
-     *          creator. Puts the orb on cooldown. The Orb can only be invoked by solvent holders.
+     * @notice  Invokes the Orb. Allows the holder to submit content hash, that represents a question to the Orb
+     *          creator. Puts the Orb on cooldown. The Orb can only be invoked by solvent holders.
      * @dev     Content hash is keccak256 of the cleartext.
      *          invocationCount is used to track the id of the next invocation.
      *          Emits Invocation().
@@ -942,13 +942,13 @@ contract Orb is ERC721, Ownable {
 
     /**
      * @notice  Orb holder can flag a response during Response Flagging Period, counting from when the response is made.
-     *          Flag indicates a "report", that the orb holder was not satisfied with the response provided.
-     *          This is meant to act as a social signal to future orb holders. It also increments flaggedResponsesCount,
+     *          Flag indicates a "report", that the Orb holder was not satisfied with the response provided.
+     *          This is meant to act as a social signal to future Orb holders. It also increments flaggedResponsesCount,
      *          allowing anyone to quickly look up how many responses were flagged.
      * @dev     Only existing responses (with non-zero timestamps) can be flagged.
      *          Responses can only be flagged by solvent holders to keep it consistent with {invokeWithHash()} or
      *          {invokeWithCleartext()}.
-     *          Also, the holder must have received the orb after the response was made;
+     *          Also, the holder must have received the Orb after the response was made;
      *          this is to prevent holders from flagging responses that were made in response to others' invocations.
      *          Emits ResponseFlagging().
      * @param   invocationId  ID of an invocation to which the response is being flagged.

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -134,15 +134,6 @@ contract Orb is ERC721, Ownable {
     // Harberger Tax period: for how long the Tax Rate applies. Value: 1 year.
     uint256 public constant HOLDER_TAX_PERIOD = 365 days;
 
-    // Auction starting price.
-    uint256 public immutable auctionStartingPrice;
-    // Each bid has to increase over previous bid by at least this much.
-    uint256 public immutable auctionMinimumBidStep;
-    // Auction will run for at least this long.
-    uint256 public immutable auctionMinimumDuration;
-    // If remaining time is less than this after a bid is made, auction will continue for at least this long.
-    uint256 public immutable auctionBidExtension;
-
     // Internal Constants
     // Orb tokenId. Can be whatever arbitrary number, only one token will ever exist.
     uint256 internal constant TOKEN_ID = 69;
@@ -174,6 +165,14 @@ contract Orb is ERC721, Ownable {
     uint256 public royaltyNumerator = 1_000;
 
     // Auction State Variables
+    // Auction starting price.
+    uint256 public auctionStartingPrice = 0.1 ether;
+    // Each bid has to increase over previous bid by at least this much.
+    uint256 public auctionMinimumBidStep = 0.1 ether;
+    // Auction will run for at least this long.
+    uint256 public auctionMinimumDuration = 1 days;
+    // If remaining time is less than this after a bid is made, auction will continue for at least this long.
+    uint256 public auctionBidExtension = 5 minutes;
     // Start Time: when the auction was started. Stays fixed during the auction, otherwise 0.
     uint256 public auctionStartTime;
     // End Time: when the auction ends, can be extended by late bids. 0 not during the auction.
@@ -224,25 +223,11 @@ contract Orb is ERC721, Ownable {
      *       This token represents the Orb and is called the Orb elsewhere in the contract.
      *       {Ownable} sets the deployer to be the owner, and also the creator in the Orb context.
      * @param cooldown_  How often Orb can be invoked.
-     * @param auctionMinimumDuration_  Minimum length for an auction.
-     * @param auctionBidExtension_     If remaining time is less than this after a bid is made,
-     *                                 auction will continue for at least this long.
      * @param beneficiary_             Beneficiary receives all Orb proceeds.
      */
-    constructor(
-        uint256 cooldown_,
-        uint256 auctionMinimumDuration_,
-        uint256 auctionBidExtension_,
-        address beneficiary_,
-        uint256 auctionStartingPrice_,
-        uint256 auctionMinimumBidStep_
-    ) ERC721("Orb", "ORB") {
+    constructor(uint256 cooldown_, address beneficiary_) ERC721("Orb", "ORB") {
         cooldown = cooldown_;
-        auctionMinimumDuration = auctionMinimumDuration_;
-        auctionBidExtension = auctionBidExtension_;
         beneficiary = beneficiary_;
-        auctionStartingPrice = auctionStartingPrice_;
-        auctionMinimumBidStep = auctionMinimumBidStep_;
 
         _safeMint(address(this), TOKEN_ID);
     }

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -60,7 +60,7 @@ contract Orb is ERC721, Ownable {
     ////////////////////////////////////////////////////////////////////////////////
 
     // Auction Events
-    event AuctionStarted(uint256 auctionStartTime, uint256 auctionEndTime);
+    event AuctionStart(uint256 auctionStartTime, uint256 auctionEndTime);
     event AuctionBid(address indexed bidder, uint256 bid);
     event AuctionExtended(uint256 newAuctionEndTime);
     event AuctionFinalized(address indexed winner, uint256 winningBid);
@@ -452,7 +452,7 @@ contract Orb is ERC721, Ownable {
      *          Important to set auctionEndTime to 0 after auction is finalized.
      *          Also, resets leadingBidder and leadingBid.
      *          Should not be necessary, as {finalizeAuction()} also does that.
-     *          Emits AuctionStarted().
+     *          Emits AuctionStart().
      */
     function startAuction() external onlyOwner onlyContractHeld notDuringAuction {
         if (auctionEndTime > 0) {
@@ -464,7 +464,7 @@ contract Orb is ERC721, Ownable {
         leadingBidder = address(0);
         leadingBid = 0;
 
-        emit AuctionStarted(auctionStartTime, auctionEndTime);
+        emit AuctionStart(auctionStartTime, auctionEndTime);
     }
 
     /**

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -66,7 +66,7 @@ contract Orb is ERC721, Ownable {
     event AuctionFinalized(address indexed winner, uint256 winningBid);
 
     // Fund Management, Holding and Purchasing Events
-    event Deposit(address indexed sender, uint256 amount);
+    event Deposit(address indexed depositor, uint256 amount);
     event Withdrawal(address indexed recipient, uint256 amount);
     event Settlement(address indexed from, address indexed to, uint256 amount);
     event NewPrice(uint256 from, uint256 to);

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -142,8 +142,8 @@ contract Orb is ERC721, Ownable {
     uint256 public immutable holderTaxNumerator;
     // Harberger Tax period: for how long the Tax Rate applies. Value: 1 year.
     uint256 public constant HOLDER_TAX_PERIOD = 365 days;
-    // Secondary sale royalties paid to beneficiary, based on sale price.
-    uint256 public immutable saleRoyaltiesNumerator;
+    // Secondary sale royalty paid to beneficiary, based on sale price.
+    uint256 public immutable royaltyNumerator;
 
     // Auction starting price.
     uint256 public immutable auctionStartingPrice;
@@ -238,7 +238,7 @@ contract Orb is ERC721, Ownable {
         uint256 auctionBidExtension_,
         address beneficiary_,
         uint256 holderTaxNumerator_,
-        uint256 saleRoyaltiesNumerator_,
+        uint256 royaltyNumerator_,
         uint256 auctionStartingPrice_,
         uint256 auctionMinimumBidStep_
     ) ERC721("Orb", "ORB") {
@@ -248,7 +248,7 @@ contract Orb is ERC721, Ownable {
         auctionBidExtension = auctionBidExtension_;
         beneficiary = beneficiary_;
         holderTaxNumerator = holderTaxNumerator_;
-        saleRoyaltiesNumerator = saleRoyaltiesNumerator_;
+        royaltyNumerator = royaltyNumerator_;
         auctionStartingPrice = auctionStartingPrice_;
         auctionMinimumBidStep = auctionMinimumBidStep_;
 
@@ -699,7 +699,7 @@ contract Orb is ERC721, Ownable {
      *          re-auctioned.
      *          Purchaser is required to have more funds than the price itself, but the exact amount is left for the
      *          user interface implementation to calculate and send along.
-     *          Purchasing sends Sale Royalties part to the beneficiary.
+     *          Purchasing sends sale royalty part to the beneficiary.
      * @dev     Requires to provide the current price as the first parameter to prevent front-running: without current
      *          price requirement someone could purchase the orb ahead of someone else, set the price higher, and
      *          profit from the purchase.
@@ -741,10 +741,10 @@ contract Orb is ERC721, Ownable {
         if (owner() == holder) {
             fundsOf[beneficiary] += currentPrice;
         } else {
-            uint256 beneficiaryRoyalties = (currentPrice * saleRoyaltiesNumerator) / FEE_DENOMINATOR;
-            uint256 currentOwnerShare = currentPrice - beneficiaryRoyalties;
+            uint256 beneficiaryRoyalty = (currentPrice * royaltyNumerator) / FEE_DENOMINATOR;
+            uint256 currentOwnerShare = currentPrice - beneficiaryRoyalty;
 
-            fundsOf[beneficiary] += beneficiaryRoyalties;
+            fundsOf[beneficiary] += beneficiaryRoyalty;
             fundsOf[holder] += currentOwnerShare;
         }
 

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -75,7 +75,7 @@ contract Orb is ERC721, Ownable {
 
     // Triggering and Responding Events
     event Invocation(address indexed invoker, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
-    event Responded(address indexed from, uint256 indexed triggerId, bytes32 contentHash, uint256 time);
+    event Response(address indexed responder, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
     event CleartextRecorded(uint256 indexed triggerId, string cleartext);
     event ResponseFlagged(address indexed from, uint256 indexed responseId);
 
@@ -921,7 +921,7 @@ contract Orb is ERC721, Ownable {
      * @notice  The Orb issuer can use this function to respond to any existing trigger, no matter how long ago
      *          it was made. A response to a trigger can only be written once. There is no way to record response
      *          cleartext on-chain.
-     * @dev     Emits Responded().
+     * @dev     Emits Response().
      * @param   triggerId  ID of a trigger to which the response is being made.
      * @param   contentHash  keccak256 hash of the response text.
      */
@@ -936,7 +936,7 @@ contract Orb is ERC721, Ownable {
 
         responses[triggerId] = HashTime(contentHash, block.timestamp);
 
-        emit Responded(msg.sender, triggerId, contentHash, block.timestamp);
+        emit Response(msg.sender, triggerId, contentHash, block.timestamp);
     }
 
     /**

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -857,7 +857,7 @@ contract Orb is ERC721, Ownable {
             revert CleartextTooLong(length, CLEARTEXT_MAXIMUM_LENGTH);
         }
         emit CleartextRecorded(invocationCount, cleartext);
-        triggerWithHash(keccak256(abi.encodePacked(cleartext)));
+        invokeWithHash(keccak256(abi.encodePacked(cleartext)));
     }
 
     /**
@@ -870,7 +870,7 @@ contract Orb is ERC721, Ownable {
      *          Emits Triggered().
      * @param   contentHash  Required keccak256 hash of the cleartext.
      */
-    function triggerWithHash(bytes32 contentHash) public onlyHolder onlyHolderHeld onlyHolderSolvent {
+    function invokeWithHash(bytes32 contentHash) public onlyHolder onlyHolderHeld onlyHolderSolvent {
         if (block.timestamp < lastInvocationTime + cooldown) {
             revert CooldownIncomplete(lastInvocationTime + cooldown - block.timestamp);
         }

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -69,7 +69,7 @@ contract Orb is ERC721, Ownable {
     event Deposit(address indexed depositor, uint256 amount);
     event Withdrawal(address indexed recipient, uint256 amount);
     event Settlement(address indexed holder, address indexed beneficiary, uint256 amount);
-    event PriceUpdated(uint256 previousPrice, uint256 newPrice);
+    event PriceUpdate(uint256 previousPrice, uint256 newPrice);
     event Purchase(address indexed seller, address indexed buyer, uint256 price);
     event Foreclosure(address indexed formerHolder, bool indexed voluntary);
 
@@ -514,7 +514,7 @@ contract Orb is ERC721, Ownable {
      *          If no bids were made, resets the state to allow the auction to be started again later.
      * @dev     Critical state transition function. Called after auctionEndTime, but only if it's not 0.
      *          Can be called by anyone, although probably will be called by the issuer or the winner.
-     *          Emits PriceUpdated() and AuctionFinalization().
+     *          Emits PriceUpdate() and AuctionFinalization().
      */
     function finalizeAuction() external notDuringAuction {
         if (auctionEndTime == 0) {
@@ -529,7 +529,7 @@ contract Orb is ERC721, Ownable {
             lastInvocationTime = block.timestamp - cooldown;
 
             emit AuctionFinalization(leadingBidder, leadingBid);
-            emit PriceUpdated(0, price);
+            emit PriceUpdate(0, price);
             // price has been set when bidding
 
             _transferOrb(address(this), leadingBidder);
@@ -685,7 +685,7 @@ contract Orb is ERC721, Ownable {
      *          Settles before adjusting the price, as the new price will change foreclosure time.
      *          Does not check if the new price differs from the previous price: no risk.
      *          Limits the price to MAX_PRICE to prevent potential overflows in math.
-     *          Emits PriceUpdated().
+     *          Emits PriceUpdate().
      * @param   newPrice  New price for the orb.
      */
     function setPrice(uint256 newPrice) external onlyHolder onlyHolderSolvent settles {
@@ -705,7 +705,7 @@ contract Orb is ERC721, Ownable {
      *          profit from the purchase.
      *          Does not modify last trigger time, unlike buying from the auction.
      *          Does not allow purchasing from yourself.
-     *          Emits PriceUpdated() and Purchase().
+     *          Emits PriceUpdate() and Purchase().
      * @param   currentPrice  Current price, to prevent front-running.
      * @param   newPrice  New price to use after the purchase.
      */
@@ -768,7 +768,7 @@ contract Orb is ERC721, Ownable {
         uint256 oldPrice = price;
         price = newPrice_;
 
-        emit PriceUpdated(oldPrice, newPrice_);
+        emit PriceUpdate(oldPrice, newPrice_);
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -877,13 +877,13 @@ contract Orb is ERC721, Ownable {
             revert CooldownIncomplete(lastInvocationTime + cooldown - block.timestamp);
         }
 
-        uint256 triggerId = invocationCount;
+        uint256 invocationId = invocationCount;
 
-        invocations[triggerId] = contentHash;
+        invocations[invocationId] = contentHash;
         lastInvocationTime = block.timestamp;
         invocationCount += 1;
 
-        emit Invocation(msg.sender, triggerId, contentHash, block.timestamp);
+        emit Invocation(msg.sender, invocationId, contentHash, block.timestamp);
     }
 
     /**

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -138,14 +138,15 @@ contract Orb is ERC721, Ownable {
     // Orb tokenId. Can be whatever arbitrary number, only one token will ever exist.
     uint256 internal immutable tokenId;
 
-    // Base URL for tokenURL JSONs.
-    string internal constant BASE_URL = "https://static.orb.land/orb/";
     // Special value returned when foreclosure time is "never".
     uint256 internal constant INFINITY = type(uint256).max;
     // Maximum Orb price, limited to prevent potential overflows.
     uint256 internal constant MAX_PRICE = 2 ** 128;
 
     // STATE
+
+    // Base URL for tokenURL JSONs.
+    string internal baseURL = "https://static.orb.land/orb/";
 
     // Funds tracker, per address. Modified by deposits, withdrawals and settlements.
     // The value is without settlement. It means effective user funds (withdrawable) would be different
@@ -358,8 +359,8 @@ contract Orb is ERC721, Ownable {
     //  FUNCTIONS: ERC-721 OVERRIDES
     ////////////////////////////////////////////////////////////////////////////////
 
-    function _baseURI() internal pure override returns (string memory) {
-        return BASE_URL;
+    function _baseURI() internal view override returns (string memory) {
+        return baseURL;
     }
 
     /**

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -634,19 +634,19 @@ contract Orb is ERC721, Ownable {
      *          to user's wallet. The only function in the contract that sends value and has re-entrancy risk.
      *          Does not check if the address is payable, as the Address library reverts if it is not.
      *          Emits Withdrawal().
-     * @param   receiver  The address to send the value to.
+     * @param   recipient_  The address to send the value to.
      * @param   amount_  The value in wei to withdraw from the contract.
      */
-    function _withdraw(address receiver, uint256 amount_) internal {
-        if (fundsOf[receiver] < amount_) {
-            revert InsufficientFunds(fundsOf[receiver], amount_);
+    function _withdraw(address recipient_, uint256 amount_) internal {
+        if (fundsOf[recipient_] < amount_) {
+            revert InsufficientFunds(fundsOf[recipient_], amount_);
         }
 
-        fundsOf[receiver] -= amount_;
+        fundsOf[recipient_] -= amount_;
 
-        emit Withdrawal(receiver, amount_);
+        emit Withdrawal(recipient_, amount_);
 
-        Address.sendValue(payable(receiver), amount_);
+        Address.sendValue(payable(recipient_), amount_);
     }
 
     /**

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -208,7 +208,7 @@ contract Orb is ERC721, Ownable {
     // Mapping for Triggers (Orb Invocations): triggerId to contentHash (bytes32).
     mapping(uint256 => bytes32) public triggers;
     // Count of triggers made. Used to calculate triggerId of the next trigger.
-    uint256 public triggersCount = 0;
+    uint256 public invocationCount = 0;
     // Mapping for Responses (Replies to Triggers): matching triggerId to HashTime struct.
     mapping(uint256 => HashTime) public responses;
     // Additional mapping for flagged (reported) Responses. Used by the holder not satisfied with a response.
@@ -856,7 +856,7 @@ contract Orb is ERC721, Ownable {
         if (length > CLEARTEXT_MAXIMUM_LENGTH) {
             revert CleartextTooLong(length, CLEARTEXT_MAXIMUM_LENGTH);
         }
-        emit CleartextRecorded(triggersCount, cleartext);
+        emit CleartextRecorded(invocationCount, cleartext);
         triggerWithHash(keccak256(abi.encodePacked(cleartext)));
     }
 
@@ -866,7 +866,7 @@ contract Orb is ERC721, Ownable {
      *          Puts the orb on cooldown.
      *          The Orb can only be triggered by solvent holders.
      * @dev     Content hash is keccak256 of the cleartext.
-     *          triggersCount is used to track the id of the next trigger.
+     *          invocationCount is used to track the id of the next trigger.
      *          Emits Triggered().
      * @param   contentHash  Required keccak256 hash of the cleartext.
      */
@@ -875,11 +875,11 @@ contract Orb is ERC721, Ownable {
             revert CooldownIncomplete(lastInvocationTime + cooldown - block.timestamp);
         }
 
-        uint256 triggerId = triggersCount;
+        uint256 triggerId = invocationCount;
 
         triggers[triggerId] = contentHash;
         lastInvocationTime = block.timestamp;
-        triggersCount += 1;
+        invocationCount += 1;
 
         emit Triggered(msg.sender, triggerId, contentHash, block.timestamp);
     }
@@ -922,7 +922,7 @@ contract Orb is ERC721, Ownable {
      * @param   contentHash  keccak256 hash of the response text.
      */
     function respond(uint256 triggerId, bytes32 contentHash) external onlyOwner {
-        if (triggerId >= triggersCount) {
+        if (triggerId >= invocationCount) {
             revert TriggerNotFound(triggerId);
         }
 

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -63,7 +63,7 @@ contract Orb is ERC721, Ownable {
     event AuctionStart(uint256 auctionStartTime, uint256 auctionEndTime);
     event AuctionBid(address indexed bidder, uint256 bid);
     event AuctionExtension(uint256 newAuctionEndTime);
-    event AuctionFinalized(address indexed winner, uint256 winningBid);
+    event AuctionFinalization(address indexed winner, uint256 winningBid);
 
     // Fund Management, Holding and Purchasing Events
     event Deposit(address indexed depositor, uint256 amount);
@@ -514,7 +514,7 @@ contract Orb is ERC721, Ownable {
      *          If no bids were made, resets the state to allow the auction to be started again later.
      * @dev     Critical state transition function. Called after auctionEndTime, but only if it's not 0.
      *          Can be called by anyone, although probably will be called by the issuer or the winner.
-     *          Emits PriceUpdated() and AuctionFinalized().
+     *          Emits PriceUpdated() and AuctionFinalization().
      */
     function finalizeAuction() external notDuringAuction {
         if (auctionEndTime == 0) {
@@ -528,7 +528,7 @@ contract Orb is ERC721, Ownable {
             lastSettlementTime = block.timestamp;
             lastInvocationTime = block.timestamp - cooldown;
 
-            emit AuctionFinalized(leadingBidder, leadingBid);
+            emit AuctionFinalization(leadingBidder, leadingBid);
             emit PriceUpdated(0, price);
             // price has been set when bidding
 
@@ -537,7 +537,7 @@ contract Orb is ERC721, Ownable {
             leadingBid = 0;
         } else {
             price = 0;
-            emit AuctionFinalized(leadingBidder, leadingBid);
+            emit AuctionFinalization(leadingBidder, leadingBid);
         }
 
         auctionStartTime = 0;

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -69,7 +69,7 @@ contract Orb is ERC721, Ownable {
     event Deposit(address indexed depositor, uint256 amount);
     event Withdrawal(address indexed recipient, uint256 amount);
     event Settlement(address indexed holder, address indexed beneficiary, uint256 amount);
-    event NewPrice(uint256 from, uint256 to);
+    event PriceUpdated(uint256 previousPrice, uint256 newPrice);
     event Purchase(address indexed from, address indexed to, uint256 price);
     event Foreclosure(address indexed from, bool indexed voluntary);
 
@@ -514,7 +514,7 @@ contract Orb is ERC721, Ownable {
      *          If no bids were made, resets the state to allow the auction to be started again later.
      * @dev     Critical state transition function. Called after auctionEndTime, but only if it's not 0.
      *          Can be called by anyone, although probably will be called by the issuer or the winner.
-     *          Emits NewPrice() and AuctionFinalized().
+     *          Emits PriceUpdated() and AuctionFinalized().
      */
     function finalizeAuction() external notDuringAuction {
         if (auctionEndTime == 0) {
@@ -529,7 +529,7 @@ contract Orb is ERC721, Ownable {
             lastInvocationTime = block.timestamp - cooldown;
 
             emit AuctionFinalized(leadingBidder, leadingBid);
-            emit NewPrice(0, price);
+            emit PriceUpdated(0, price);
             // price has been set when bidding
 
             _transferOrb(address(this), leadingBidder);
@@ -685,7 +685,7 @@ contract Orb is ERC721, Ownable {
      *          Settles before adjusting the price, as the new price will change foreclosure time.
      *          Does not check if the new price differs from the previous price: no risk.
      *          Limits the price to MAX_PRICE to prevent potential overflows in math.
-     *          Emits NewPrice().
+     *          Emits PriceUpdated().
      * @param   newPrice  New price for the orb.
      */
     function setPrice(uint256 newPrice) external onlyHolder onlyHolderSolvent settles {
@@ -705,7 +705,7 @@ contract Orb is ERC721, Ownable {
      *          profit from the purchase.
      *          Does not modify last trigger time, unlike buying from the auction.
      *          Does not allow purchasing from yourself.
-     *          Emits NewPrice() and Purchase().
+     *          Emits PriceUpdated() and Purchase().
      * @param   currentPrice  Current price, to prevent front-running.
      * @param   newPrice  New price to use after the purchase.
      */
@@ -768,7 +768,7 @@ contract Orb is ERC721, Ownable {
         uint256 oldPrice = price;
         price = newPrice_;
 
-        emit NewPrice(oldPrice, newPrice_);
+        emit PriceUpdated(oldPrice, newPrice_);
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -765,10 +765,10 @@ contract Orb is ERC721, Ownable {
             revert InvalidNewPrice(newPrice_);
         }
 
-        uint256 oldPrice = price;
+        uint256 previousPrice = price;
         price = newPrice_;
 
-        emit PriceUpdate(oldPrice, newPrice_);
+        emit PriceUpdate(previousPrice, newPrice_);
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -291,7 +291,7 @@ contract Orb is ERC721, Ownable {
 
     /**
      * @dev  Ensures that the orb belongs to the contract itself, either because it hasn't been auctioned,
-     *       or because it has returned to the contract due to {exit()} or {foreclose()}
+     *       or because it has returned to the contract due to {relinquish()} or {foreclose()}
      */
     modifier onlyContractHeld() {
         if (address(this) != ERC721.ownerOf(TOKEN_ID)) {
@@ -565,7 +565,7 @@ contract Orb is ERC721, Ownable {
 
     /**
      * @notice  Function to withdraw all funds on the contract.
-     *          Not recommended for current orb holders, they should call exit() to take out their funds.
+     *          Not recommended for current orb holders, they should call relinquish() to take out their funds.
      * @dev     Not allowed for the winning auction bidder.
      */
     function withdrawAll() external notLeadingBidder settlesIfHolder {
@@ -776,14 +776,14 @@ contract Orb is ERC721, Ownable {
     ////////////////////////////////////////////////////////////////////////////////
 
     /**
-     * @notice  Exit is a voluntary giving up of the orb. It's a combination of withdrawing all funds not owed to
-     *          the issuer since last settlement, and foreclosing yourself after.
+     * @notice  Relinquishment is a voluntary giving up of the orb. It's a combination of withdrawing all funds
+     *          not owed to the issuer since last settlement, and foreclosing yourself after.
      *          Most useful if the issuer themselves hold the orb and want to re-auction it.
      *          For any other holder, setting the price to zero would be more practical.
      * @dev     Calls _withdraw(), which does value transfer from the contract.
      *          Emits Foreclosure() and Withdrawal().
      */
-    function exit() external onlyHolder onlyHolderSolvent settles {
+    function relinquish() external onlyHolder onlyHolderSolvent settles {
         price = 0;
 
         emit Foreclosure(msg.sender, true);

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -896,7 +896,11 @@ contract Orb is ERC721, Ownable {
      * @param   triggerId  Triggred id, matching the one that was emitted when calling {trigger()}.
      * @param   cleartext  Cleartext, limited in length. Must match the content hash.
      */
-    function recordTriggerCleartext(uint256 triggerId, string memory cleartext) external onlyHolder onlyHolderSolvent {
+    function recordInvocationCleartext(uint256 triggerId, string memory cleartext)
+        external
+        onlyHolder
+        onlyHolderSolvent
+    {
         uint256 cleartextLength = bytes(cleartext).length;
 
         if (cleartextLength > CLEARTEXT_MAXIMUM_LENGTH) {

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -410,9 +410,9 @@ contract Orb is ERC721, Ownable {
      *          If the new owner is not this contract (an actual user), updates holderReceiveTime.
      *          holderReceiveTime is used to limit response flagging window.
      */
-    function _transferOrb(address from, address to) internal {
-        _transfer(from, to, TOKEN_ID);
-        if (to != address(this)) {
+    function _transferOrb(address from_, address to_) internal {
+        _transfer(from_, to_, TOKEN_ID);
+        if (to_ != address(this)) {
             holderReceiveTime = block.timestamp;
         }
     }

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -113,7 +113,7 @@ contract Orb is ERC721, Ownable {
     error CooldownIncomplete(uint256 timeRemaining);
     error CleartextTooLong(uint256 cleartextLength, uint256 cleartextMaximumLength);
     error CleartextHashMismatch(bytes32 cleartextHash, bytes32 recordedContentHash);
-    error TriggerNotFound(uint256 triggerId);
+    error InvocationNotFound(uint256 invocationId);
     error ResponseNotFound(uint256 triggerId);
     error ResponseExists(uint256 triggerId);
     error FlaggingPeriodExpired(uint256 triggerId, uint256 currentTimeValue, uint256 timeValueLimit);
@@ -927,7 +927,7 @@ contract Orb is ERC721, Ownable {
      */
     function respond(uint256 triggerId, bytes32 contentHash) external onlyOwner {
         if (triggerId >= invocationCount) {
-            revert TriggerNotFound(triggerId);
+            revert InvocationNotFound(triggerId);
         }
 
         if (_responseExists(triggerId)) {

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -71,7 +71,7 @@ contract Orb is ERC721, Ownable {
     event Settlement(address indexed holder, address indexed beneficiary, uint256 amount);
     event PriceUpdated(uint256 previousPrice, uint256 newPrice);
     event Purchase(address indexed seller, address indexed buyer, uint256 price);
-    event Foreclosure(address indexed from, bool indexed voluntary);
+    event Foreclosure(address indexed formerHolder, bool indexed voluntary);
 
     // Triggering and Responding Events
     event Triggered(address indexed from, uint256 indexed triggerId, bytes32 contentHash, uint256 time);

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -117,7 +117,7 @@ contract Orb is ERC721, Ownable {
     error ResponseNotFound(uint256 invocationId);
     error ResponseExists(uint256 invocationId);
     error FlaggingPeriodExpired(uint256 invocationId, uint256 currentTimeValue, uint256 timeValueLimit);
-    error ResponseAlreadyFlagged(uint256 triggerId);
+    error ResponseAlreadyFlagged(uint256 invocationId);
 
     ////////////////////////////////////////////////////////////////////////////////
     //  STORAGE

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -154,6 +154,12 @@ contract Orb is ERC721, Ownable {
     // If Orb is held by the creator, funds are not subtracted, as Harberger Tax does not apply to the creator.
     mapping(address => uint256) public fundsOf;
 
+    // Taxes State Variables
+
+    // Harberger Tax for holding. Initial value is 10%.
+    uint256 public holderTaxNumerator = 1_000;
+    // Secondary sale royalty paid to beneficiary, based on sale price.
+    uint256 public royaltyNumerator = 1_000;
     // Price of the Orb. No need for mapping, as only one token is ever minted.
     // Also used during auction to store future purchase price.
     // Shouldn't be useful if the Orb is held by the contract.
@@ -161,12 +167,9 @@ contract Orb is ERC721, Ownable {
     // Last time Orb holder's funds were settled.
     // Shouldn't be useful if the Orb is held by the contract.
     uint256 public lastSettlementTime;
-    // Harberger Tax for holding. Initial value is 10%.
-    uint256 public holderTaxNumerator = 1_000;
-    // Secondary sale royalty paid to beneficiary, based on sale price.
-    uint256 public royaltyNumerator = 1_000;
 
     // Auction State Variables
+
     // Auction starting price.
     uint256 public auctionStartingPrice = 0.1 ether;
     // Each bid has to increase over previous bid by at least this much.
@@ -195,15 +198,14 @@ contract Orb is ERC721, Ownable {
         uint256 timestamp;
     }
 
+    // Cooldown: how often Orb can be invoked.
+    uint256 public cooldown = 7 days;
+    // Maximum length for invocation cleartext content.
+    uint256 public cleartextMaximumLength = 280;
     // Holder Receive Time: When the Orb was last transferred, except to this contract.
     uint256 public holderReceiveTime;
     // Last Invocation Time: when the Orb was last invoked. Used together with Cooldown constant.
     uint256 public lastInvocationTime;
-
-    // Cooldown: how often Orb can be invoked.
-    uint256 public cooldown;
-    // Maximum length for invocation cleartext content.
-    uint256 public cleartextMaximumLength = 280;
 
     // Mapping for Invocation: invocationId to contentHash (bytes32).
     mapping(uint256 => bytes32) public invocations;

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -115,7 +115,7 @@ contract Orb is ERC721, Ownable {
     error CleartextHashMismatch(bytes32 cleartextHash, bytes32 recordedContentHash);
     error InvocationNotFound(uint256 invocationId);
     error ResponseNotFound(uint256 invocationId);
-    error ResponseExists(uint256 triggerId);
+    error ResponseExists(uint256 invocationId);
     error FlaggingPeriodExpired(uint256 triggerId, uint256 currentTimeValue, uint256 timeValueLimit);
     error ResponseAlreadyFlagged(uint256 triggerId);
 

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -63,7 +63,7 @@ contract Orb is ERC721, Ownable {
     event AuctionStarted(uint256 auctionStartTime, uint256 auctionEndTime);
     event AuctionBid(address indexed bidder, uint256 bid);
     event AuctionExtended(uint256 newAuctionEndTime);
-    event AuctionFinalized(address indexed winner, uint256 price);
+    event AuctionFinalized(address indexed winner, uint256 winningBid);
 
     // Fund Management, Holding and Purchasing Events
     event Deposit(address indexed sender, uint256 amount);

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -77,7 +77,7 @@ contract Orb is ERC721, Ownable {
     event Invocation(address indexed invoker, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
     event Response(address indexed responder, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
     event CleartextRecorded(uint256 indexed invocationId, string cleartext);
-    event ResponseFlagged(address indexed from, uint256 indexed responseId);
+    event ResponseFlagging(address indexed flagger, uint256 indexed invocationId);
 
     ////////////////////////////////////////////////////////////////////////////////
     //  ERRORS
@@ -948,7 +948,7 @@ contract Orb is ERC721, Ownable {
      *          Responses can only be flagged by solvent holders to keep it consistent with {trigger()}.
      *          Also, the holder must have received the orb after the response was made;
      *          this is to prevent holders from flagging responses that were made in response to others' triggers.
-     *          Emits ResponseFlagged().
+     *          Emits ResponseFlagging().
      * @param   triggerId  ID of a trigger to which the response is being flagged.
      */
     function flagResponse(uint256 triggerId) external onlyHolder onlyHolderSolvent {
@@ -971,7 +971,7 @@ contract Orb is ERC721, Ownable {
         responseFlagged[triggerId] = true;
         flaggedResponsesCount += 1;
 
-        emit ResponseFlagged(msg.sender, triggerId);
+        emit ResponseFlagging(msg.sender, triggerId);
     }
 
     /**

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -76,7 +76,7 @@ contract Orb is ERC721, Ownable {
     // Triggering and Responding Events
     event Invocation(address indexed invoker, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
     event Response(address indexed responder, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
-    event CleartextRecorded(uint256 indexed invocationId, string cleartext);
+    event CleartextRecording(uint256 indexed invocationId, string cleartext);
     event ResponseFlagging(address indexed flagger, uint256 indexed invocationId);
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -856,7 +856,7 @@ contract Orb is ERC721, Ownable {
         if (length > CLEARTEXT_MAXIMUM_LENGTH) {
             revert CleartextTooLong(length, CLEARTEXT_MAXIMUM_LENGTH);
         }
-        emit CleartextRecorded(invocationCount, cleartext);
+        emit CleartextRecording(invocationCount, cleartext);
         invokeWithHash(keccak256(abi.encodePacked(cleartext)));
     }
 
@@ -914,7 +914,7 @@ contract Orb is ERC721, Ownable {
             revert CleartextHashMismatch(cleartextHash, recordedContentHash);
         }
 
-        emit CleartextRecorded(triggerId, cleartext);
+        emit CleartextRecording(triggerId, cleartext);
     }
 
     /**

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -111,7 +111,7 @@ contract Orb is ERC721, Ownable {
 
     // Triggering and Responding Errors
     error CooldownIncomplete(uint256 timeRemaining);
-    error CleartextTooLong(uint256 cleartextLength, uint256 maxLength);
+    error CleartextTooLong(uint256 cleartextLength, uint256 cleartextMaximumLength);
     error CleartextHashMismatch(bytes32 cleartextHash, bytes32 contentHash);
     error TriggerNotFound(uint256 triggerId);
     error ResponseNotFound(uint256 triggerId);

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -133,8 +133,6 @@ contract Orb is ERC721, Ownable {
 
     // Harberger Tax period: for how long the Tax Rate applies. Value: 1 year.
     uint256 public constant HOLDER_TAX_PERIOD = 365 days;
-    // Secondary sale royalty paid to beneficiary, based on sale price.
-    uint256 public immutable royaltyNumerator;
 
     // Auction starting price.
     uint256 public immutable auctionStartingPrice;
@@ -172,6 +170,8 @@ contract Orb is ERC721, Ownable {
     uint256 public lastSettlementTime;
     // Harberger Tax for holding. Initial value is 10%.
     uint256 public holderTaxNumerator = 1_000;
+    // Secondary sale royalty paid to beneficiary, based on sale price.
+    uint256 public royaltyNumerator = 1_000;
 
     // Auction State Variables
     // Start Time: when the auction was started. Stays fixed during the auction, otherwise 0.
@@ -234,8 +234,6 @@ contract Orb is ERC721, Ownable {
         uint256 auctionMinimumDuration_,
         uint256 auctionBidExtension_,
         address beneficiary_,
-        uint256 holderTaxNumerator_,
-        uint256 royaltyNumerator_,
         uint256 auctionStartingPrice_,
         uint256 auctionMinimumBidStep_
     ) ERC721("Orb", "ORB") {
@@ -243,8 +241,6 @@ contract Orb is ERC721, Ownable {
         auctionMinimumDuration = auctionMinimumDuration_;
         auctionBidExtension = auctionBidExtension_;
         beneficiary = beneficiary_;
-        holderTaxNumerator = holderTaxNumerator_;
-        royaltyNumerator = royaltyNumerator_;
         auctionStartingPrice = auctionStartingPrice_;
         auctionMinimumBidStep = auctionMinimumBidStep_;
 

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -410,9 +410,9 @@ contract Orb is ERC721, Ownable {
      *          If the new owner is not this contract (an actual user), updates holderReceiveTime.
      *          holderReceiveTime is used to limit response flagging window.
      */
-    function _transferOrb(address oldAddress, address newAddress) internal {
-        _transfer(oldAddress, newAddress, TOKEN_ID);
-        if (newAddress != address(this)) {
+    function _transferOrb(address from, address to) internal {
+        _transfer(from, to, TOKEN_ID);
+        if (to != address(this)) {
             holderReceiveTime = block.timestamp;
         }
     }

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -226,12 +226,11 @@ contract Orb is ERC721, Ownable {
      * @dev  When deployed, contract mints the only token that will ever exist, to itself.
      *       This token represents the Orb and is called the Orb elsewhere in the contract.
      *       {Ownable} sets the deployer to be the owner, and also the creator in the Orb context.
-     * @param cooldown_  How often Orb can be invoked.
-     * @param beneficiary_             Beneficiary receives all Orb proceeds.
+     * @param tokenId_      ERC-721 token ID of the Orb.
+     * @param beneficiary_  Beneficiary receives all Orb proceeds.
      */
-    constructor(uint256 tokenId_, uint256 cooldown_, address beneficiary_) ERC721("Orb", "ORB") {
+    constructor(uint256 tokenId_, address beneficiary_) ERC721("Orb", "ORB") {
         tokenId = tokenId_;
-        cooldown = cooldown_;
         beneficiary = beneficiary_;
 
         _safeMint(address(this), tokenId);

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -129,8 +129,6 @@ contract Orb is ERC721, Ownable {
     address public immutable beneficiary;
 
     // Public Constants
-    // Maximum length for invocation cleartext content.
-    uint256 public constant CLEARTEXT_MAXIMUM_LENGTH = 280;
 
     // Fee Nominator: basis points. Other fees are in relation to this.
     uint256 public constant FEE_DENOMINATOR = 10000;
@@ -161,9 +159,6 @@ contract Orb is ERC721, Ownable {
     uint256 internal constant MAX_PRICE = 2 ** 128;
 
     // STATE
-
-    // Cooldown: how often Orb can be invoked.
-    uint256 public cooldown;
 
     // Funds tracker, per address. Modified by deposits, withdrawals and settlements.
     // The value is without settlement. It means effective user funds (withdrawable) would be different
@@ -204,6 +199,12 @@ contract Orb is ERC721, Ownable {
     uint256 public holderReceiveTime;
     // Last Invocation Time: when the Orb was last invoked. Used together with Cooldown constant.
     uint256 public lastInvocationTime;
+
+    // Cooldown: how often Orb can be invoked.
+    uint256 public cooldown;
+    // Maximum length for invocation cleartext content.
+    uint256 public cleartextMaximumLength = 280;
+
     // Mapping for Invocation: invocationId to contentHash (bytes32).
     mapping(uint256 => bytes32) public invocations;
     // Count of invocations made. Used to calculate invocationId of the next invocation.
@@ -851,8 +852,8 @@ contract Orb is ERC721, Ownable {
      */
     function invokeWithCleartext(string memory cleartext) external {
         uint256 length = bytes(cleartext).length;
-        if (length > CLEARTEXT_MAXIMUM_LENGTH) {
-            revert CleartextTooLong(length, CLEARTEXT_MAXIMUM_LENGTH);
+        if (length > cleartextMaximumLength) {
+            revert CleartextTooLong(length, cleartextMaximumLength);
         }
         emit CleartextRecording(invocationCount, cleartext);
         invokeWithHash(keccak256(abi.encodePacked(cleartext)));
@@ -900,8 +901,8 @@ contract Orb is ERC721, Ownable {
     {
         uint256 cleartextLength = bytes(cleartext).length;
 
-        if (cleartextLength > CLEARTEXT_MAXIMUM_LENGTH) {
-            revert CleartextTooLong(cleartextLength, CLEARTEXT_MAXIMUM_LENGTH);
+        if (cleartextLength > cleartextMaximumLength) {
+            revert CleartextTooLong(cleartextLength, cleartextMaximumLength);
         }
 
         bytes32 recordedContentHash = invocations[invocationId];

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -114,7 +114,7 @@ contract Orb is ERC721, Ownable {
     error CleartextTooLong(uint256 cleartextLength, uint256 cleartextMaximumLength);
     error CleartextHashMismatch(bytes32 cleartextHash, bytes32 recordedContentHash);
     error InvocationNotFound(uint256 invocationId);
-    error ResponseNotFound(uint256 triggerId);
+    error ResponseNotFound(uint256 invocationId);
     error ResponseExists(uint256 triggerId);
     error FlaggingPeriodExpired(uint256 triggerId, uint256 currentTimeValue, uint256 timeValueLimit);
     error ResponseAlreadyFlagged(uint256 triggerId);

--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -18,7 +18,7 @@ contract DeployMainnetTest is Test {
     }
 
     function testOrbOwnership() public {
-        assertEq(deployScript.orb().owner(), deployScript.issuerWallet());
+        assertEq(deployScript.orb().owner(), deployScript.creatorAddress());
     }
 
     function testBeneficiary() public {

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1183,7 +1183,7 @@ contract InvokeWithCleartextTest is OrbTestBase {
         orb.invokeWithCleartext(text);
     }
 
-    function test_callsTriggerHashCorrectly() public {
+    function test_callsInvokeWithHashCorrectly() public {
         string memory text = "fjasdklfjasdklfjasdasdffakfjsad;lfs;lf;flksajf;lk";
         makeHolderAndWarp(user, 1 ether);
         vm.expectEmit(true, false, false, true);
@@ -1345,7 +1345,7 @@ contract RespondTest is OrbTestBase {
         orb.respond(0, response);
     }
 
-    function test_revertWhen_triggerIdIncorrect() public {
+    function test_revertWhen_invocationIdIncorrect() public {
         makeHolderAndWarp(user, 1 ether);
         string memory cleartext = "this is a cleartext";
         bytes32 response = "response hash";

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -131,7 +131,7 @@ contract MinimumBidTest is OrbTestBase {
 }
 
 contract StartAuctionTest is OrbTestBase {
-    function test_startAuctionOnlyOrbIssuer() public {
+    function test_startAuctionOnlyOrbCreator() public {
         vm.prank(address(0xBEEF));
         vm.expectRevert("Ownable: caller is not the owner");
         orb.startAuction();
@@ -434,7 +434,7 @@ contract EffectiveFundsOfTest is OrbTestBase {
 
         // One day has passed since the orb holder got the orb
         // for bid = 1 ether. That means that the price of the
-        // orb is now 1 ether. Thus the Orb issuer is owed the tax
+        // orb is now 1 ether. Thus the Orb beneficiary is owed the tax
         // for 1 day.
 
         // The user actually transfered `funds1` and `funds2` respectively

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -376,7 +376,7 @@ contract FinalizeAuctionTest is OrbTestBase {
         assertEq(orb.price(), 0);
     }
 
-    event NewPrice(uint256 oldPrice, uint256 newPrice);
+    event PriceUpdated(uint256 previousPrice, uint256 newPrice);
 
     function test_finalizeAuctionWithWinner() public {
         orb.startAuction();
@@ -396,7 +396,7 @@ contract FinalizeAuctionTest is OrbTestBase {
         vm.expectEmit(true, false, false, true);
         emit AuctionFinalized(user, amount);
         vm.expectEmit(false, false, false, true);
-        emit NewPrice(0, amount);
+        emit PriceUpdated(0, amount);
 
         orb.finalizeAuction();
 
@@ -865,7 +865,7 @@ contract SetPriceTest is OrbTestBase {
         assertEq(orb.lastSettlementTime(), block.timestamp);
     }
 
-    event NewPrice(uint256 oldPrice, uint256 newPrice);
+    event PriceUpdated(uint256 previousPrice, uint256 newPrice);
 
     function test_setPriceRevertsIfMaxPrice() public {
         uint256 maxPrice = orb.workaround_maxPrice();
@@ -876,7 +876,7 @@ contract SetPriceTest is OrbTestBase {
         orb.setPrice(maxPrice + 1);
 
         vm.expectEmit(false, false, false, true);
-        emit NewPrice(10 ether, maxPrice);
+        emit PriceUpdated(10 ether, maxPrice);
         orb.setPrice(maxPrice);
     }
 }
@@ -942,7 +942,7 @@ contract PurchaseTest is OrbTestBase {
 
     event Purchase(address indexed from, address indexed to, uint256 price);
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
-    event NewPrice(uint256 from, uint256 to);
+    event PriceUpdated(uint256 previousPrice, uint256 newPrice);
     event Settlement(address indexed holder, address indexed beneficiary, uint256 amount);
 
     function test_beneficiaryAllProceedsIfOwnerSells() public {
@@ -993,7 +993,7 @@ contract PurchaseTest is OrbTestBase {
         // we just settled above
         emit Settlement(user, beneficiary, 0);
         vm.expectEmit(false, false, false, true);
-        emit NewPrice(bidAmount, newPrice);
+        emit PriceUpdated(bidAmount, newPrice);
         vm.expectEmit(true, true, false, true);
         emit Purchase(user, user2, bidAmount);
         vm.expectEmit(true, true, true, false);
@@ -1033,7 +1033,7 @@ contract PurchaseTest is OrbTestBase {
         // we just settled above
         emit Settlement(user, beneficiary, 0);
         vm.expectEmit(false, false, false, true);
-        emit NewPrice(bidAmount, newPrice);
+        emit PriceUpdated(bidAmount, newPrice);
         vm.expectEmit(true, true, false, true);
         emit Purchase(user, user2, bidAmount);
         vm.expectEmit(true, true, true, false);

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -80,7 +80,7 @@ contract InitialStateTest is OrbTestBase {
         assertEq(orb.beneficiary(), address(0xC0FFEE));
 
         assertEq(orb.price(), 0);
-        assertEq(orb.lastTriggerTime(), 0);
+        assertEq(orb.lastInvocationTime(), 0);
         assertEq(orb.triggersCount(), 0);
 
         assertEq(orb.flaggedResponsesCount(), 0);
@@ -413,7 +413,7 @@ contract FinalizeAuctionTest is OrbTestBase {
         assertEq(orb.fundsOf(beneficiary), amount);
         assertEq(orb.ownerOf(orb.workaround_orbId()), user);
         assertEq(orb.lastSettlementTime(), block.timestamp);
-        assertEq(orb.lastTriggerTime(), block.timestamp - orb.cooldown());
+        assertEq(orb.lastInvocationTime(), block.timestamp - orb.cooldown());
         assertEq(orb.fundsOf(user), funds - amount);
         assertEq(orb.price(), amount);
     }
@@ -1247,7 +1247,7 @@ contract TriggerWthHashTest is OrbTestBase {
         emit Triggered(user, 0, hash, block.timestamp);
         orb.triggerWithHash(hash);
         assertEq(orb.triggers(0), hash);
-        assertEq(orb.lastTriggerTime(), block.timestamp);
+        assertEq(orb.lastInvocationTime(), block.timestamp);
         assertEq(orb.triggersCount(), 1);
     }
 }

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -288,7 +288,7 @@ contract BidTest is OrbTestBase {
 
     mapping(address => uint256) internal fundsOfUser;
 
-    event AuctionFinalized(address indexed winner, uint256 winningBid);
+    event AuctionFinalization(address indexed winner, uint256 winningBid);
 
     function testFuzz_bidSetsCorrectState(address[16] memory bidders, uint128[16] memory amounts) public {
         orb.startAuction();
@@ -314,7 +314,7 @@ contract BidTest is OrbTestBase {
             assertEq(address(orb).balance, contractBalance);
         }
         vm.expectEmit(true, false, false, true);
-        emit AuctionFinalized(orb.leadingBidder(), orb.leadingBid());
+        emit AuctionFinalization(orb.leadingBidder(), orb.leadingBid());
         vm.warp(orb.auctionEndTime() + 1);
         orb.finalizeAuction();
     }
@@ -340,7 +340,7 @@ contract BidTest is OrbTestBase {
 }
 
 contract FinalizeAuctionTest is OrbTestBase {
-    event AuctionFinalized(address indexed winner, uint256 winningBid);
+    event AuctionFinalization(address indexed winner, uint256 winningBid);
 
     function test_finalizeAuctionRevertsDuringAuction() public {
         orb.startAuction();
@@ -349,7 +349,7 @@ contract FinalizeAuctionTest is OrbTestBase {
 
         vm.warp(orb.auctionEndTime() + 1);
         vm.expectEmit(true, false, false, true);
-        emit AuctionFinalized(address(0), 0);
+        emit AuctionFinalization(address(0), 0);
         orb.finalizeAuction();
     }
 
@@ -367,7 +367,7 @@ contract FinalizeAuctionTest is OrbTestBase {
         orb.startAuction();
         vm.warp(orb.auctionEndTime() + 1);
         vm.expectEmit(true, false, false, true);
-        emit AuctionFinalized(address(0), 0);
+        emit AuctionFinalization(address(0), 0);
         orb.finalizeAuction();
         assertEq(orb.auctionEndTime(), 0);
         assertEq(orb.auctionStartTime(), 0);
@@ -394,7 +394,7 @@ contract FinalizeAuctionTest is OrbTestBase {
         assertEq(orb.fundsOf(address(orb)), 0);
 
         vm.expectEmit(true, false, false, true);
-        emit AuctionFinalized(user, amount);
+        emit AuctionFinalization(user, amount);
         vm.expectEmit(false, false, false, true);
         emit PriceUpdated(0, amount);
 

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1326,7 +1326,7 @@ contract RecordInvocationCleartext is OrbTestBase {
 }
 
 contract RespondTest is OrbTestBase {
-    event Responded(address indexed from, uint256 indexed triggerId, bytes32 contentHash, uint256 time);
+    event Response(address indexed responder, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
 
     function test_revertWhen_notOwner() public {
         makeHolderAndWarp(user, 1 ether);
@@ -1341,7 +1341,7 @@ contract RespondTest is OrbTestBase {
 
         vm.prank(owner);
         vm.expectEmit(true, true, false, true);
-        emit Responded(owner, 0, response, block.timestamp);
+        emit Response(owner, 0, response, block.timestamp);
         orb.respond(0, response);
     }
 
@@ -1388,7 +1388,7 @@ contract RespondTest is OrbTestBase {
 
         vm.prank(owner);
         vm.expectEmit(true, true, false, true);
-        emit Responded(owner, 0, response, block.timestamp);
+        emit Response(owner, 0, response, block.timestamp);
         orb.respond(0, response);
         (bytes32 hash, uint256 time) = orb.responses(0);
         assertEq(hash, response);

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1225,7 +1225,7 @@ contract InvokeWthHashTest is OrbTestBase {
         bytes32 hash = "asdfsaf";
         vm.startPrank(user);
         orb.invokeWithHash(hash);
-        assertEq(orb.triggers(0), hash);
+        assertEq(orb.invocations(0), hash);
         vm.warp(block.timestamp + 1 days);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1233,10 +1233,10 @@ contract InvokeWthHashTest is OrbTestBase {
             )
         );
         orb.invokeWithHash(hash);
-        assertEq(orb.triggers(1), bytes32(0));
+        assertEq(orb.invocations(1), bytes32(0));
         vm.warp(block.timestamp + orb.cooldown() - 1 days + 1);
         orb.invokeWithHash(hash);
-        assertEq(orb.triggers(1), hash);
+        assertEq(orb.invocations(1), hash);
     }
 
     function test_success() public {
@@ -1246,7 +1246,7 @@ contract InvokeWthHashTest is OrbTestBase {
         vm.expectEmit(true, true, false, true);
         emit Invocation(user, 0, hash, block.timestamp);
         orb.invokeWithHash(hash);
-        assertEq(orb.triggers(0), hash);
+        assertEq(orb.invocations(0), hash);
         assertEq(orb.lastInvocationTime(), block.timestamp);
         assertEq(orb.invocationCount(), 1);
     }

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -967,8 +967,8 @@ contract PurchaseTest is OrbTestBase {
         // It uses both the existing funds of the user and the funds
         // that the user transfers when calling `purchase()`
         orb.purchase{value: purchaseAmount + 1}(bidAmount, newPrice);
-        uint256 beneficiaryRoyalties = bidAmount;
-        assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalties);
+        uint256 beneficiaryRoyalty = bidAmount;
+        assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty);
         assertEq(orb.fundsOf(owner), ownerBefore);
         // The price of the Orb was 1 ether and user2 transfered 1 ether + 1 to buy it
         assertEq(orb.fundsOf(user), 1);
@@ -1002,9 +1002,9 @@ contract PurchaseTest is OrbTestBase {
         // It uses both the existing funds of the user and the funds
         // that the user transfers when calling `purchase()`
         orb.purchase{value: purchaseAmount + 1}(bidAmount, newPrice);
-        uint256 beneficiaryRoyalties = ((bidAmount * 1000) / 10000);
-        assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalties);
-        assertEq(orb.fundsOf(user), userBefore + (bidAmount - beneficiaryRoyalties));
+        uint256 beneficiaryRoyalty = ((bidAmount * 1000) / 10000);
+        assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty);
+        assertEq(orb.fundsOf(user), userBefore + (bidAmount - beneficiaryRoyalty));
         assertEq(orb.fundsOf(owner), ownerBefore);
         // The price of the Orb was 1 ether and user2 transfered 1 ether + 1 to buy it
         assertEq(orb.fundsOf(user2), 1);
@@ -1043,9 +1043,9 @@ contract PurchaseTest is OrbTestBase {
         // that the user transfers when calling `purchase()`
         // We bound the purchaseAmount to be higher than the current price (bidAmount)
         orb.purchase{value: purchaseAmount}(bidAmount, newPrice);
-        uint256 beneficiaryRoyalties = ((bidAmount * 1000) / 10000);
-        assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalties);
-        assertEq(orb.fundsOf(user), userBefore + (bidAmount - beneficiaryRoyalties));
+        uint256 beneficiaryRoyalty = ((bidAmount * 1000) / 10000);
+        assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty);
+        assertEq(orb.fundsOf(user), userBefore + (bidAmount - beneficiaryRoyalty));
         assertEq(orb.fundsOf(owner), ownerBefore);
         // User2 transfered buyPrice to the contract
         // User2 paid bidAmount

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -81,7 +81,7 @@ contract InitialStateTest is OrbTestBase {
 
         assertEq(orb.price(), 0);
         assertEq(orb.lastInvocationTime(), 0);
-        assertEq(orb.triggersCount(), 0);
+        assertEq(orb.invocationCount(), 0);
 
         assertEq(orb.flaggedResponsesCount(), 0);
 
@@ -1248,7 +1248,7 @@ contract TriggerWthHashTest is OrbTestBase {
         orb.triggerWithHash(hash);
         assertEq(orb.triggers(0), hash);
         assertEq(orb.lastInvocationTime(), block.timestamp);
-        assertEq(orb.triggersCount(), 1);
+        assertEq(orb.invocationCount(), 1);
     }
 }
 

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1171,7 +1171,7 @@ contract ForeclosureTimeTest is OrbTestBase {
 }
 
 contract InvokeWithCleartextTest is OrbTestBase {
-    event Triggered(address indexed from, uint256 indexed triggerId, bytes32 contentHash, uint256 time);
+    event Invocation(address indexed invoker, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
     event CleartextRecorded(uint256 indexed triggerId, string cleartext);
 
     function test_revertsIfLongLength() public {
@@ -1189,14 +1189,14 @@ contract InvokeWithCleartextTest is OrbTestBase {
         vm.expectEmit(true, false, false, true);
         emit CleartextRecorded(0, text);
         vm.expectEmit(true, true, false, true);
-        emit Triggered(user, 0, keccak256(abi.encodePacked(text)), block.timestamp);
+        emit Invocation(user, 0, keccak256(abi.encodePacked(text)), block.timestamp);
         vm.prank(user);
         orb.invokeWithCleartext(text);
     }
 }
 
 contract InvokeWthHashTest is OrbTestBase {
-    event Triggered(address indexed from, uint256 indexed triggerId, bytes32 contentHash, uint256 time);
+    event Invocation(address indexed invoker, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
 
     function test_revertWhen_NotHolder() public {
         makeHolderAndWarp(user, 1 ether);
@@ -1206,7 +1206,7 @@ contract InvokeWthHashTest is OrbTestBase {
         orb.invokeWithHash(hash);
 
         vm.expectEmit(true, false, false, true);
-        emit Triggered(user, 0, hash, block.timestamp);
+        emit Invocation(user, 0, hash, block.timestamp);
         vm.prank(user);
         orb.invokeWithHash(hash);
     }
@@ -1244,7 +1244,7 @@ contract InvokeWthHashTest is OrbTestBase {
         bytes32 hash = "asdfsaf";
         vm.startPrank(user);
         vm.expectEmit(true, true, false, true);
-        emit Triggered(user, 0, hash, block.timestamp);
+        emit Invocation(user, 0, hash, block.timestamp);
         orb.invokeWithHash(hash);
         assertEq(orb.triggers(0), hash);
         assertEq(orb.lastInvocationTime(), block.timestamp);

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -432,9 +432,9 @@ contract EffectiveFundsOfTest is OrbTestBase {
         orb.finalizeAuction();
         vm.warp(block.timestamp + 1 days);
 
-        // One day has passed since the orb holder got the orb
+        // One day has passed since the Orb holder got the orb
         // for bid = 1 ether. That means that the price of the
-        // orb is now 1 ether. Thus the Orb beneficiary is owed the tax
+        // Orb is now 1 ether. Thus the Orb beneficiary is owed the tax
         // for 1 day.
 
         // The user actually transfered `funds1` and `funds2` respectively
@@ -462,16 +462,16 @@ contract EffectiveFundsOfTest is OrbTestBase {
         orb.finalizeAuction();
         vm.warp(block.timestamp + 1 days);
 
-        // One day has passed since the orb holder got the orb
+        // One day has passed since the Orb holder got the Orb
         // for bid = 1 ether. That means that the price of the
-        // orb is now 1 ether. Thus the Orb beneficiary is owed the tax
+        // Orb is now 1 ether. Thus the Orb beneficiary is owed the tax
         // for 1 day.
 
         // The user actually transfered `funds1` and `funds2` respectively
         // ether to the contract
         uint256 owed = orb.workaround_owedSinceLastSettlement();
         assertEq(effectiveFundsOf(beneficiary), owed + amount1);
-        // The user that won the auction and is holding the orb
+        // The user that won the auction and is holding the Orb
         // has the funds they deposited, minus the tax and minus the bid
         // amount
         assertEq(effectiveFundsOf(user), funds1 - owed - amount1);
@@ -898,7 +898,7 @@ contract PurchaseTest is OrbTestBase {
 
     function test_purchaseSettlesFirst() public {
         makeHolderAndWarp(user, 1 ether);
-        // after making `user` the current holder of the orb, `makeHolderAndWarp(user, )` warps 30 days into the future
+        // after making `user` the current holder of the Orb, `makeHolderAndWarp(user, )` warps 30 days into the future
         assertEq(orb.lastSettlementTime(), block.timestamp - 30 days);
         vm.prank(user2);
         orb.purchase{value: 1.1 ether}(1 ether, 2 ether);
@@ -1081,7 +1081,7 @@ contract RelinquishmentTest is OrbTestBase {
 
     function test_settlesFirst() public {
         makeHolderAndWarp(user, 1 ether);
-        // after making `user` the current holder of the orb, `makeHolderAndWarp(user, )` warps 30 days into the future
+        // after making `user` the current holder of the Orb, `makeHolderAndWarp(user, )` warps 30 days into the future
         assertEq(orb.lastSettlementTime(), block.timestamp - 30 days);
         vm.prank(user);
         orb.relinquish();

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -139,14 +139,14 @@ contract StartAuctionTest is OrbTestBase {
         assertEq(orb.auctionStartTime(), block.timestamp);
     }
 
-    event AuctionStarted(uint256 auctionStartTime, uint256 auctionEndTime);
+    event AuctionStart(uint256 auctionStartTime, uint256 auctionEndTime);
 
     function test_startAuctionCorrectly() public {
         assertEq(orb.auctionStartTime(), 0);
         orb.workaround_setLeadingBid(10);
         orb.workaround_setLeadingBidder(address(0xBEEF));
         vm.expectEmit(true, true, false, false);
-        emit AuctionStarted(block.timestamp, block.timestamp + orb.auctionMinimumDuration());
+        emit AuctionStart(block.timestamp, block.timestamp + orb.auctionMinimumDuration());
         orb.startAuction();
         assertEq(orb.auctionStartTime(), block.timestamp);
         assertEq(orb.auctionEndTime(), block.timestamp + orb.auctionMinimumDuration());
@@ -160,13 +160,13 @@ contract StartAuctionTest is OrbTestBase {
         orb.startAuction();
         orb.workaround_setOrbHolder(address(orb));
         vm.expectEmit(true, true, false, false);
-        emit AuctionStarted(block.timestamp, block.timestamp + orb.auctionMinimumDuration());
+        emit AuctionStart(block.timestamp, block.timestamp + orb.auctionMinimumDuration());
         orb.startAuction();
     }
 
     function test_startAuctionNotDuringAuction() public {
         vm.expectEmit(true, true, false, false);
-        emit AuctionStarted(block.timestamp, block.timestamp + orb.auctionMinimumDuration());
+        emit AuctionStart(block.timestamp, block.timestamp + orb.auctionMinimumDuration());
         orb.startAuction();
         vm.expectRevert(Orb.AuctionRunning.selector);
         orb.startAuction();

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1203,12 +1203,12 @@ contract TriggerWthHashTest is OrbTestBase {
         bytes32 hash = "asdfsaf";
         vm.prank(user2);
         vm.expectRevert(Orb.NotHolder.selector);
-        orb.triggerWithHash(hash);
+        orb.invokeWithHash(hash);
 
         vm.expectEmit(true, false, false, true);
         emit Triggered(user, 0, hash, block.timestamp);
         vm.prank(user);
-        orb.triggerWithHash(hash);
+        orb.invokeWithHash(hash);
     }
 
     function test_revertWhen_HolderInsolvent() public {
@@ -1217,14 +1217,14 @@ contract TriggerWthHashTest is OrbTestBase {
         vm.warp(block.timestamp + 13130000 days);
         vm.prank(user);
         vm.expectRevert(Orb.HolderInsolvent.selector);
-        orb.triggerWithHash(hash);
+        orb.invokeWithHash(hash);
     }
 
     function test_revertWhen_CooldownIncomplete() public {
         makeHolderAndWarp(user, 1 ether);
         bytes32 hash = "asdfsaf";
         vm.startPrank(user);
-        orb.triggerWithHash(hash);
+        orb.invokeWithHash(hash);
         assertEq(orb.triggers(0), hash);
         vm.warp(block.timestamp + 1 days);
         vm.expectRevert(
@@ -1232,10 +1232,10 @@ contract TriggerWthHashTest is OrbTestBase {
                 Orb.CooldownIncomplete.selector, block.timestamp - 1 days + orb.cooldown() - block.timestamp
             )
         );
-        orb.triggerWithHash(hash);
+        orb.invokeWithHash(hash);
         assertEq(orb.triggers(1), bytes32(0));
         vm.warp(block.timestamp + orb.cooldown() - 1 days + 1);
-        orb.triggerWithHash(hash);
+        orb.invokeWithHash(hash);
         assertEq(orb.triggers(1), hash);
     }
 
@@ -1245,7 +1245,7 @@ contract TriggerWthHashTest is OrbTestBase {
         vm.startPrank(user);
         vm.expectEmit(true, true, false, true);
         emit Triggered(user, 0, hash, block.timestamp);
-        orb.triggerWithHash(hash);
+        orb.invokeWithHash(hash);
         assertEq(orb.triggers(0), hash);
         assertEq(orb.lastInvocationTime(), block.timestamp);
         assertEq(orb.invocationCount(), 1);
@@ -1263,7 +1263,7 @@ contract RecordTriggerCleartext is OrbTestBase {
         orb.recordTriggerCleartext(0, cleartext);
 
         vm.startPrank(user);
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         orb.recordTriggerCleartext(0, cleartext);
     }
 
@@ -1277,7 +1277,7 @@ contract RecordTriggerCleartext is OrbTestBase {
 
         vm.warp(block.timestamp - 13130000 days);
         vm.startPrank(user);
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         orb.recordTriggerCleartext(0, cleartext);
     }
 
@@ -1287,14 +1287,14 @@ contract RecordTriggerCleartext is OrbTestBase {
         uint256 max = orb.CLEARTEXT_MAXIMUM_LENGTH();
         string memory cleartext =
             "asfsafsfsafsafasdfasfdsakfjdsakfjasdlkfajsdlfsdlfkasdfjdjasfhasdljhfdaslkfjsda;kfjasdklfjasdklfjasd;ladlkfjasdfad;flksadjf;lkasdjf;lsadsdlsdlkfjas;dlkfjas;dlkfjsad;lkfjsad;lda;lkfj;kasjf;klsadjf;lsadsdlkfjasd;lkfjsad;lfkajsd;flkasdjf;lsdkfjas;lfkasdflkasdf;laskfj;asldkfjsad;lfs;lf;flksajf;lk"; // solhint-disable-line
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         uint256 length = bytes(cleartext).length;
         vm.expectRevert(abi.encodeWithSelector(Orb.CleartextTooLong.selector, length, max));
         orb.recordTriggerCleartext(0, cleartext);
 
         vm.warp(block.timestamp + orb.cooldown() + 1);
         cleartext = "this is a cleartext";
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         orb.recordTriggerCleartext(1, cleartext);
     }
 
@@ -1303,7 +1303,7 @@ contract RecordTriggerCleartext is OrbTestBase {
         vm.startPrank(user);
         string memory cleartext = "this is a cleartext";
         string memory cleartext2 = "this is not the same cleartext";
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         vm.expectRevert(
             abi.encodeWithSelector(
                 Orb.CleartextHashMismatch.selector, keccak256(bytes(cleartext2)), keccak256(bytes(cleartext))
@@ -1320,7 +1320,7 @@ contract RecordTriggerCleartext is OrbTestBase {
         vm.startPrank(user);
         vm.expectEmit(true, false, false, true);
         emit CleartextRecorded(0, cleartext);
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         orb.recordTriggerCleartext(0, cleartext);
     }
 }
@@ -1333,7 +1333,7 @@ contract RespondTest is OrbTestBase {
         string memory cleartext = "this is a cleartext";
         bytes32 response = "response hash";
         vm.startPrank(user);
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         orb.recordTriggerCleartext(0, cleartext);
         vm.expectRevert("Ownable: caller is not the owner");
         orb.respond(0, response);
@@ -1350,7 +1350,7 @@ contract RespondTest is OrbTestBase {
         string memory cleartext = "this is a cleartext";
         bytes32 response = "response hash";
         vm.startPrank(user);
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         orb.recordTriggerCleartext(0, cleartext);
         vm.stopPrank();
 
@@ -1367,7 +1367,7 @@ contract RespondTest is OrbTestBase {
         string memory cleartext = "this is a cleartext";
         bytes32 response = "response hash";
         vm.startPrank(user);
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         orb.recordTriggerCleartext(0, cleartext);
         vm.stopPrank();
 
@@ -1382,7 +1382,7 @@ contract RespondTest is OrbTestBase {
         string memory cleartext = "this is a cleartext";
         bytes32 response = "response hash";
         vm.startPrank(user);
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         orb.recordTriggerCleartext(0, cleartext);
         vm.stopPrank();
 
@@ -1404,7 +1404,7 @@ contract FlagResponseTest is OrbTestBase {
         string memory cleartext = "this is a cleartext";
         bytes32 response = "response hash";
         vm.prank(user);
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         vm.prank(owner);
         orb.respond(0, response);
         vm.prank(user2);
@@ -1420,7 +1420,7 @@ contract FlagResponseTest is OrbTestBase {
         string memory cleartext = "this is a cleartext";
         bytes32 response = "response hash";
         vm.prank(user);
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         vm.prank(owner);
         orb.respond(0, response);
         vm.warp(block.timestamp + 13130000 days);
@@ -1438,7 +1438,7 @@ contract FlagResponseTest is OrbTestBase {
         string memory cleartext = "this is a cleartext";
         bytes32 response = "response hash";
         vm.prank(user);
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         vm.prank(owner);
         orb.respond(0, response);
 
@@ -1454,7 +1454,7 @@ contract FlagResponseTest is OrbTestBase {
         string memory cleartext = "this is a cleartext";
         bytes32 response = "response hash";
         vm.prank(user);
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         vm.prank(owner);
         orb.respond(0, response);
 
@@ -1474,7 +1474,7 @@ contract FlagResponseTest is OrbTestBase {
         string memory cleartext = "this is a cleartext";
         bytes32 response = "response hash";
         vm.prank(user);
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         vm.prank(owner);
         orb.respond(0, response);
 
@@ -1486,7 +1486,7 @@ contract FlagResponseTest is OrbTestBase {
         orb.flagResponse(0);
 
         vm.warp(block.timestamp + orb.cooldown());
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         vm.stopPrank();
         vm.prank(owner);
         orb.respond(1, response);
@@ -1499,7 +1499,7 @@ contract FlagResponseTest is OrbTestBase {
         string memory cleartext = "this is a cleartext";
         bytes32 response = "response hash";
         vm.prank(user);
-        orb.triggerWithHash(keccak256(bytes(cleartext)));
+        orb.invokeWithHash(keccak256(bytes(cleartext)));
         vm.prank(owner);
         orb.respond(0, response);
         vm.prank(user);

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1172,7 +1172,7 @@ contract ForeclosureTimeTest is OrbTestBase {
 
 contract InvokeWithCleartextTest is OrbTestBase {
     event Invocation(address indexed invoker, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
-    event CleartextRecorded(uint256 indexed triggerId, string cleartext);
+    event CleartextRecorded(uint256 indexed invocationId, string cleartext);
 
     function test_revertsIfLongLength() public {
         uint256 max = orb.CLEARTEXT_MAXIMUM_LENGTH();
@@ -1253,7 +1253,7 @@ contract InvokeWthHashTest is OrbTestBase {
 }
 
 contract RecordInvocationCleartext is OrbTestBase {
-    event CleartextRecorded(uint256 indexed triggerId, string cleartext);
+    event CleartextRecorded(uint256 indexed invocationId, string cleartext);
 
     function test_revertWhen_NotHolder() public {
         makeHolderAndWarp(user, 1 ether);

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1397,7 +1397,7 @@ contract RespondTest is OrbTestBase {
 }
 
 contract FlagResponseTest is OrbTestBase {
-    event ResponseFlagged(address indexed from, uint256 indexed responseId);
+    event ResponseFlagging(address indexed flagger, uint256 indexed invocationId);
 
     function test_revertWhen_NotHolder() public {
         makeHolderAndWarp(user, 1 ether);
@@ -1506,7 +1506,7 @@ contract FlagResponseTest is OrbTestBase {
         assertEq(orb.responseFlagged(0), false);
         assertEq(orb.flaggedResponsesCount(), 0);
         vm.expectEmit(true, false, false, true);
-        emit ResponseFlagged(user, 0);
+        emit ResponseFlagging(user, 0);
         vm.prank(user);
         orb.flagResponse(0);
         assertEq(orb.responseFlagged(0), true);

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1054,16 +1054,16 @@ contract PurchaseTest is OrbTestBase {
     }
 }
 
-contract ExitTest is OrbTestBase {
+contract RelinquishmentTest is OrbTestBase {
     function test_revertsIfNotHolder() public {
         uint256 leadingBid = 10 ether;
         makeHolderAndWarp(user, leadingBid);
         vm.expectRevert(Orb.NotHolder.selector);
         vm.prank(user2);
-        orb.exit();
+        orb.relinquish();
 
         vm.prank(user);
-        orb.exit();
+        orb.relinquish();
         assertEq(orb.ownerOf(orb.workaround_orbId()), address(orb));
     }
 
@@ -1072,10 +1072,10 @@ contract ExitTest is OrbTestBase {
         vm.warp(block.timestamp + 1300 days);
         vm.prank(user);
         vm.expectRevert(Orb.HolderInsolvent.selector);
-        orb.exit();
+        orb.relinquish();
         vm.warp(block.timestamp - 1300 days);
         vm.prank(user);
-        orb.exit();
+        orb.relinquish();
         assertEq(orb.ownerOf(orb.workaround_orbId()), address(orb));
     }
 
@@ -1084,7 +1084,7 @@ contract ExitTest is OrbTestBase {
         // after making `user` the current holder of the orb, `makeHolderAndWarp(user, )` warps 30 days into the future
         assertEq(orb.lastSettlementTime(), block.timestamp - 30 days);
         vm.prank(user);
-        orb.exit();
+        orb.relinquish();
         assertEq(orb.lastSettlementTime(), block.timestamp);
     }
 
@@ -1101,7 +1101,7 @@ contract ExitTest is OrbTestBase {
         uint256 effectiveFunds = effectiveFundsOf(user);
         emit Withdrawal(user, effectiveFunds);
         vm.prank(user);
-        orb.exit();
+        orb.relinquish();
         assertEq(orb.ownerOf(orb.workaround_orbId()), address(orb));
         assertEq(orb.price(), 0);
     }

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1172,7 +1172,7 @@ contract ForeclosureTimeTest is OrbTestBase {
 
 contract InvokeWithCleartextTest is OrbTestBase {
     event Invocation(address indexed invoker, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp);
-    event CleartextRecorded(uint256 indexed invocationId, string cleartext);
+    event CleartextRecording(uint256 indexed invocationId, string cleartext);
 
     function test_revertsIfLongLength() public {
         uint256 max = orb.CLEARTEXT_MAXIMUM_LENGTH();
@@ -1187,7 +1187,7 @@ contract InvokeWithCleartextTest is OrbTestBase {
         string memory text = "fjasdklfjasdklfjasdasdffakfjsad;lfs;lf;flksajf;lk";
         makeHolderAndWarp(user, 1 ether);
         vm.expectEmit(true, false, false, true);
-        emit CleartextRecorded(0, text);
+        emit CleartextRecording(0, text);
         vm.expectEmit(true, true, false, true);
         emit Invocation(user, 0, keccak256(abi.encodePacked(text)), block.timestamp);
         vm.prank(user);
@@ -1253,7 +1253,7 @@ contract InvokeWthHashTest is OrbTestBase {
 }
 
 contract RecordInvocationCleartext is OrbTestBase {
-    event CleartextRecorded(uint256 indexed invocationId, string cleartext);
+    event CleartextRecording(uint256 indexed invocationId, string cleartext);
 
     function test_revertWhen_NotHolder() public {
         makeHolderAndWarp(user, 1 ether);
@@ -1319,7 +1319,7 @@ contract RecordInvocationCleartext is OrbTestBase {
         string memory cleartext = "this is a cleartext";
         vm.startPrank(user);
         vm.expectEmit(true, false, false, true);
-        emit CleartextRecorded(0, cleartext);
+        emit CleartextRecording(0, cleartext);
         orb.invokeWithHash(keccak256(bytes(cleartext)));
         orb.recordInvocationCleartext(0, cleartext);
     }

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -288,7 +288,7 @@ contract BidTest is OrbTestBase {
 
     mapping(address => uint256) internal fundsOfUser;
 
-    event AuctionFinalized(address indexed winner, uint256 price);
+    event AuctionFinalized(address indexed winner, uint256 winningBid);
 
     function testFuzz_bidSetsCorrectState(address[16] memory bidders, uint128[16] memory amounts) public {
         orb.startAuction();
@@ -340,7 +340,7 @@ contract BidTest is OrbTestBase {
 }
 
 contract FinalizeAuctionTest is OrbTestBase {
-    event AuctionFinalized(address indexed winner, uint256 price);
+    event AuctionFinalized(address indexed winner, uint256 winningBid);
 
     function test_finalizeAuctionRevertsDuringAuction() public {
         orb.startAuction();

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -223,7 +223,7 @@ contract BidTest is OrbTestBase {
         orb.bid{value: amount}(amount, amount);
         assertEq(orb.leadingBid(), amount);
 
-        // minimum bid will be the winning bid + MINIMUM_BID_STEP
+        // minimum bid will be the leading bid + MINIMUM_BID_STEP
         amount = orb.minimumBid() - 1;
         vm.expectRevert(abi.encodeWithSelector(Orb.InsufficientBid.selector, amount, orb.minimumBid()));
         vm.prank(user);
@@ -605,7 +605,7 @@ contract WithdrawTest is OrbTestBase {
         orb.startAuction();
         // user2 bids
         prankAndBid(user2, smallBidAmount);
-        // user1 bids and becomes the winning bidder
+        // user1 bids and becomes the leading bidder
         prankAndBid(user, bidAmount);
         vm.warp(orb.auctionEndTime() + 1);
         orb.finalizeAuction();
@@ -651,7 +651,7 @@ contract WithdrawTest is OrbTestBase {
         orb.startAuction();
         // user2 bids
         prankAndBid(user2, smallBidAmount);
-        // user1 bids and becomes the winning bidder
+        // user1 bids and becomes the leading bidder
         prankAndBid(user, bidAmount);
         vm.warp(orb.auctionEndTime() + 1);
         orb.finalizeAuction();

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1460,12 +1460,10 @@ contract FlagResponseTest is OrbTestBase {
 
         vm.warp(block.timestamp + 100 days);
         vm.startPrank(user);
-        vm.expectRevert(
-            abi.encodeWithSelector(Orb.FlaggingPeriodExpired.selector, 0, 100 days, orb.responseFlaggingPeriod())
-        );
+        vm.expectRevert(abi.encodeWithSelector(Orb.FlaggingPeriodExpired.selector, 0, 100 days, orb.cooldown()));
         orb.flagResponse(0);
 
-        vm.warp(block.timestamp - (100 days - orb.responseFlaggingPeriod()));
+        vm.warp(block.timestamp - (100 days - orb.cooldown()));
         orb.flagResponse(0);
     }
 

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -79,6 +79,8 @@ contract InitialStateTest is OrbTestBase {
         assertEq(orb.owner(), address(this));
         assertEq(orb.beneficiary(), address(0xC0FFEE));
 
+        assertEq(orb.workaround_baseUrl(), "https://static.orb.land/orb/");
+
         assertEq(orb.cleartextMaximumLength(), 280);
 
         assertEq(orb.price(), 0);
@@ -110,7 +112,6 @@ contract InitialStateTest is OrbTestBase {
         assertEq(orb.workaround_tokenId(), 69);
         assertEq(orb.workaround_infinity(), type(uint256).max);
         assertEq(orb.workaround_maxPrice(), 2 ** 128);
-        assertEq(orb.workaround_baseUrl(), "https://static.orb.land/orb/");
     }
 }
 

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1252,7 +1252,7 @@ contract InvokeWthHashTest is OrbTestBase {
     }
 }
 
-contract RecordTriggerCleartext is OrbTestBase {
+contract RecordInvocationCleartext is OrbTestBase {
     event CleartextRecorded(uint256 indexed triggerId, string cleartext);
 
     function test_revertWhen_NotHolder() public {
@@ -1260,11 +1260,11 @@ contract RecordTriggerCleartext is OrbTestBase {
         string memory cleartext = "this is a cleartext";
         vm.prank(user2);
         vm.expectRevert(Orb.NotHolder.selector);
-        orb.recordTriggerCleartext(0, cleartext);
+        orb.recordInvocationCleartext(0, cleartext);
 
         vm.startPrank(user);
         orb.invokeWithHash(keccak256(bytes(cleartext)));
-        orb.recordTriggerCleartext(0, cleartext);
+        orb.recordInvocationCleartext(0, cleartext);
     }
 
     function test_revertWhen_HolderInsolvent() public {
@@ -1273,12 +1273,12 @@ contract RecordTriggerCleartext is OrbTestBase {
         vm.warp(block.timestamp + 13130000 days);
         vm.prank(user);
         vm.expectRevert(Orb.HolderInsolvent.selector);
-        orb.recordTriggerCleartext(0, cleartext);
+        orb.recordInvocationCleartext(0, cleartext);
 
         vm.warp(block.timestamp - 13130000 days);
         vm.startPrank(user);
         orb.invokeWithHash(keccak256(bytes(cleartext)));
-        orb.recordTriggerCleartext(0, cleartext);
+        orb.recordInvocationCleartext(0, cleartext);
     }
 
     function test_revertWhen_incorrectLength() public {
@@ -1290,12 +1290,12 @@ contract RecordTriggerCleartext is OrbTestBase {
         orb.invokeWithHash(keccak256(bytes(cleartext)));
         uint256 length = bytes(cleartext).length;
         vm.expectRevert(abi.encodeWithSelector(Orb.CleartextTooLong.selector, length, max));
-        orb.recordTriggerCleartext(0, cleartext);
+        orb.recordInvocationCleartext(0, cleartext);
 
         vm.warp(block.timestamp + orb.cooldown() + 1);
         cleartext = "this is a cleartext";
         orb.invokeWithHash(keccak256(bytes(cleartext)));
-        orb.recordTriggerCleartext(1, cleartext);
+        orb.recordInvocationCleartext(1, cleartext);
     }
 
     function test_revertWhen_cleartextMismatch() public {
@@ -1309,9 +1309,9 @@ contract RecordTriggerCleartext is OrbTestBase {
                 Orb.CleartextHashMismatch.selector, keccak256(bytes(cleartext2)), keccak256(bytes(cleartext))
             )
         );
-        orb.recordTriggerCleartext(0, cleartext2);
+        orb.recordInvocationCleartext(0, cleartext2);
 
-        orb.recordTriggerCleartext(0, cleartext);
+        orb.recordInvocationCleartext(0, cleartext);
     }
 
     function test_success() public {
@@ -1321,7 +1321,7 @@ contract RecordTriggerCleartext is OrbTestBase {
         vm.expectEmit(true, false, false, true);
         emit CleartextRecorded(0, cleartext);
         orb.invokeWithHash(keccak256(bytes(cleartext)));
-        orb.recordTriggerCleartext(0, cleartext);
+        orb.recordInvocationCleartext(0, cleartext);
     }
 }
 
@@ -1334,7 +1334,7 @@ contract RespondTest is OrbTestBase {
         bytes32 response = "response hash";
         vm.startPrank(user);
         orb.invokeWithHash(keccak256(bytes(cleartext)));
-        orb.recordTriggerCleartext(0, cleartext);
+        orb.recordInvocationCleartext(0, cleartext);
         vm.expectRevert("Ownable: caller is not the owner");
         orb.respond(0, response);
         vm.stopPrank();
@@ -1351,7 +1351,7 @@ contract RespondTest is OrbTestBase {
         bytes32 response = "response hash";
         vm.startPrank(user);
         orb.invokeWithHash(keccak256(bytes(cleartext)));
-        orb.recordTriggerCleartext(0, cleartext);
+        orb.recordInvocationCleartext(0, cleartext);
         vm.stopPrank();
 
         vm.prank(owner);
@@ -1368,7 +1368,7 @@ contract RespondTest is OrbTestBase {
         bytes32 response = "response hash";
         vm.startPrank(user);
         orb.invokeWithHash(keccak256(bytes(cleartext)));
-        orb.recordTriggerCleartext(0, cleartext);
+        orb.recordInvocationCleartext(0, cleartext);
         vm.stopPrank();
 
         vm.startPrank(owner);
@@ -1383,7 +1383,7 @@ contract RespondTest is OrbTestBase {
         bytes32 response = "response hash";
         vm.startPrank(user);
         orb.invokeWithHash(keccak256(bytes(cleartext)));
-        orb.recordTriggerCleartext(0, cleartext);
+        orb.recordInvocationCleartext(0, cleartext);
         vm.stopPrank();
 
         vm.prank(owner);

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -83,6 +83,7 @@ contract InitialStateTest is OrbTestBase {
 
         assertEq(orb.price(), 0);
         assertEq(orb.holderTaxNumerator(), 1_000);
+        assertEq(orb.royaltyNumerator(), 1_000);
         assertEq(orb.lastInvocationTime(), 0);
         assertEq(orb.invocationCount(), 0);
 

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -89,6 +89,11 @@ contract InitialStateTest is OrbTestBase {
 
         assertEq(orb.flaggedResponsesCount(), 0);
 
+        assertEq(orb.auctionStartingPrice(), 0.1 ether);
+        assertEq(orb.auctionMinimumBidStep(), 0.1 ether);
+        assertEq(orb.auctionMinimumDuration(), 1 days);
+        assertEq(orb.auctionBidExtension(), 5 minutes);
+
         assertEq(orb.auctionStartTime(), 0);
         assertEq(orb.auctionEndTime(), 0);
         assertEq(orb.leadingBidder(), address(0));

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -593,7 +593,7 @@ contract WithdrawTest is OrbTestBase {
         assertEq(user.balance, startingBalance + fundsBefore);
     }
 
-    event Settlement(address indexed holder, address indexed owner, uint256 amount);
+    event Settlement(address indexed holder, address indexed beneficiary, uint256 amount);
 
     function test_withdrawSettlesFirstIfHolder() public {
         assertEq(orb.fundsOf(user), 0);
@@ -731,7 +731,7 @@ contract WithdrawTest is OrbTestBase {
 }
 
 contract SettleTest is OrbTestBase {
-    event Settlement(address indexed holder, address indexed owner, uint256 amount);
+    event Settlement(address indexed holder, address indexed beneficiary, uint256 amount);
 
     function test_settleOnlyIfHolderHeld() public {
         vm.expectRevert(Orb.ContractHoldsOrb.selector);
@@ -943,7 +943,7 @@ contract PurchaseTest is OrbTestBase {
     event Purchase(address indexed from, address indexed to, uint256 price);
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
     event NewPrice(uint256 from, uint256 to);
-    event Settlement(address indexed from, address indexed to, uint256 amount);
+    event Settlement(address indexed holder, address indexed beneficiary, uint256 amount);
 
     function test_beneficiaryAllProceedsIfOwnerSells() public {
         uint256 bidAmount = 1 ether;

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -940,7 +940,7 @@ contract PurchaseTest is OrbTestBase {
         orb.purchase{value: 1 ether - 1}(1 ether, 3 ether);
     }
 
-    event Purchase(address indexed from, address indexed to, uint256 price);
+    event Purchase(address indexed seller, address indexed buyer, uint256 price);
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
     event PriceUpdated(uint256 previousPrice, uint256 newPrice);
     event Settlement(address indexed holder, address indexed beneficiary, uint256 amount);

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1088,7 +1088,7 @@ contract RelinquishmentTest is OrbTestBase {
         assertEq(orb.lastSettlementTime(), block.timestamp);
     }
 
-    event Foreclosure(address indexed from, bool indexed voluntary);
+    event Foreclosure(address indexed formerHolder, bool indexed voluntary);
     event Withdrawal(address indexed recipient, uint256 amount);
 
     function test_succeedsCorrectly() public {
@@ -1121,7 +1121,7 @@ contract ForecloseTest is OrbTestBase {
         assertEq(orb.ownerOf(orb.workaround_orbId()), address(orb));
     }
 
-    event Foreclosure(address indexed from, bool indexed voluntary);
+    event Foreclosure(address indexed formerHolder, bool indexed voluntary);
 
     function test_revertsifHolderSolvent() public {
         uint256 leadingBid = 10 ether;

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -95,7 +95,7 @@ contract InitialStateTest is OrbTestBase {
     }
 
     function test_constants() public {
-        assertEq(orb.MAX_CLEARTEXT_LENGTH(), 280);
+        assertEq(orb.CLEARTEXT_MAXIMUM_LENGTH(), 280);
 
         assertEq(orb.FEE_DENOMINATOR(), 10000);
         assertEq(orb.HOLDER_TAX_PERIOD(), 365 days);
@@ -1175,7 +1175,7 @@ contract TriggerWithCleartextTest is OrbTestBase {
     event CleartextRecorded(uint256 indexed triggerId, string cleartext);
 
     function test_revertsIfLongLength() public {
-        uint256 max = orb.MAX_CLEARTEXT_LENGTH();
+        uint256 max = orb.CLEARTEXT_MAXIMUM_LENGTH();
         string memory text =
             "asfsafsfsafsafasdfasfdsakfjdsakfjasdlkfajsdlfsdlfkasdfjdjasfhasdljhfdaslkfjsda;kfjasdklfjasdklfjasd;ladlkfjasdfad;flksadjf;lkasdjf;lsadsdlsdlkfjas;dlkfjas;dlkfjsad;lkfjsad;lda;lkfj;kasjf;klsadjf;lsadsdlkfjasd;lkfjsad;lfkajsd;flkasdjf;lsdkfjas;lfkasdflkasdf;laskfj;asldkfjsad;lfs;lf;flksajf;lk"; // solhint-disable-line
         uint256 length = bytes(text).length;
@@ -1284,7 +1284,7 @@ contract RecordTriggerCleartext is OrbTestBase {
     function test_revertWhen_incorrectLength() public {
         makeHolderAndWarp(user, 1 ether);
         vm.startPrank(user);
-        uint256 max = orb.MAX_CLEARTEXT_LENGTH();
+        uint256 max = orb.CLEARTEXT_MAXIMUM_LENGTH();
         string memory cleartext =
             "asfsafsfsafsafasdfasfdsakfjdsakfjasdlkfajsdlfsdlfkasdfjdjasfhasdljhfdaslkfjsda;kfjasdklfjasdklfjasd;ladlkfjasdfad;flksadjf;lkasdjf;lsadsdlsdlkfjas;dlkfjas;dlkfjsad;lkfjsad;lda;lkfj;kasjf;klsadjf;lsadsdlkfjasd;lkfjsad;lfkajsd;flkasdjf;lsdkfjas;lfkasdflkasdf;laskfj;asldkfjsad;lfs;lf;flksajf;lk"; // solhint-disable-line
         orb.triggerWithHash(keccak256(bytes(cleartext)));

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -376,7 +376,7 @@ contract FinalizeAuctionTest is OrbTestBase {
         assertEq(orb.price(), 0);
     }
 
-    event PriceUpdated(uint256 previousPrice, uint256 newPrice);
+    event PriceUpdate(uint256 previousPrice, uint256 newPrice);
 
     function test_finalizeAuctionWithWinner() public {
         orb.startAuction();
@@ -396,7 +396,7 @@ contract FinalizeAuctionTest is OrbTestBase {
         vm.expectEmit(true, false, false, true);
         emit AuctionFinalization(user, amount);
         vm.expectEmit(false, false, false, true);
-        emit PriceUpdated(0, amount);
+        emit PriceUpdate(0, amount);
 
         orb.finalizeAuction();
 
@@ -865,7 +865,7 @@ contract SetPriceTest is OrbTestBase {
         assertEq(orb.lastSettlementTime(), block.timestamp);
     }
 
-    event PriceUpdated(uint256 previousPrice, uint256 newPrice);
+    event PriceUpdate(uint256 previousPrice, uint256 newPrice);
 
     function test_setPriceRevertsIfMaxPrice() public {
         uint256 maxPrice = orb.workaround_maxPrice();
@@ -876,7 +876,7 @@ contract SetPriceTest is OrbTestBase {
         orb.setPrice(maxPrice + 1);
 
         vm.expectEmit(false, false, false, true);
-        emit PriceUpdated(10 ether, maxPrice);
+        emit PriceUpdate(10 ether, maxPrice);
         orb.setPrice(maxPrice);
     }
 }
@@ -942,7 +942,7 @@ contract PurchaseTest is OrbTestBase {
 
     event Purchase(address indexed seller, address indexed buyer, uint256 price);
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
-    event PriceUpdated(uint256 previousPrice, uint256 newPrice);
+    event PriceUpdate(uint256 previousPrice, uint256 newPrice);
     event Settlement(address indexed holder, address indexed beneficiary, uint256 amount);
 
     function test_beneficiaryAllProceedsIfOwnerSells() public {
@@ -993,7 +993,7 @@ contract PurchaseTest is OrbTestBase {
         // we just settled above
         emit Settlement(user, beneficiary, 0);
         vm.expectEmit(false, false, false, true);
-        emit PriceUpdated(bidAmount, newPrice);
+        emit PriceUpdate(bidAmount, newPrice);
         vm.expectEmit(true, true, false, true);
         emit Purchase(user, user2, bidAmount);
         vm.expectEmit(true, true, true, false);
@@ -1033,7 +1033,7 @@ contract PurchaseTest is OrbTestBase {
         // we just settled above
         emit Settlement(user, beneficiary, 0);
         vm.expectEmit(false, false, false, true);
-        emit PriceUpdated(bidAmount, newPrice);
+        emit PriceUpdate(bidAmount, newPrice);
         vm.expectEmit(true, true, false, true);
         emit Purchase(user, user2, bidAmount);
         vm.expectEmit(true, true, true, false);

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1355,7 +1355,7 @@ contract RespondTest is OrbTestBase {
         vm.stopPrank();
 
         vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(Orb.TriggerNotFound.selector, 1));
+        vm.expectRevert(abi.encodeWithSelector(Orb.InvocationNotFound.selector, 1));
         orb.respond(1, response);
 
         vm.prank(owner);

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -79,6 +79,8 @@ contract InitialStateTest is OrbTestBase {
         assertEq(orb.owner(), address(this));
         assertEq(orb.beneficiary(), address(0xC0FFEE));
 
+        assertEq(orb.cleartextMaximumLength(), 280);
+
         assertEq(orb.price(), 0);
         assertEq(orb.lastInvocationTime(), 0);
         assertEq(orb.invocationCount(), 0);
@@ -95,8 +97,6 @@ contract InitialStateTest is OrbTestBase {
     }
 
     function test_constants() public {
-        assertEq(orb.CLEARTEXT_MAXIMUM_LENGTH(), 280);
-
         assertEq(orb.FEE_DENOMINATOR(), 10000);
         assertEq(orb.HOLDER_TAX_PERIOD(), 365 days);
 
@@ -1175,7 +1175,7 @@ contract InvokeWithCleartextTest is OrbTestBase {
     event CleartextRecording(uint256 indexed invocationId, string cleartext);
 
     function test_revertsIfLongLength() public {
-        uint256 max = orb.CLEARTEXT_MAXIMUM_LENGTH();
+        uint256 max = orb.cleartextMaximumLength();
         string memory text =
             "asfsafsfsafsafasdfasfdsakfjdsakfjasdlkfajsdlfsdlfkasdfjdjasfhasdljhfdaslkfjsda;kfjasdklfjasdklfjasd;ladlkfjasdfad;flksadjf;lkasdjf;lsadsdlsdlkfjas;dlkfjas;dlkfjsad;lkfjsad;lda;lkfj;kasjf;klsadjf;lsadsdlkfjasd;lkfjsad;lfkajsd;flkasdjf;lsdkfjas;lfkasdflkasdf;laskfj;asldkfjsad;lfs;lf;flksajf;lk"; // solhint-disable-line
         uint256 length = bytes(text).length;
@@ -1284,7 +1284,7 @@ contract RecordInvocationCleartext is OrbTestBase {
     function test_revertWhen_incorrectLength() public {
         makeHolderAndWarp(user, 1 ether);
         vm.startPrank(user);
-        uint256 max = orb.CLEARTEXT_MAXIMUM_LENGTH();
+        uint256 max = orb.cleartextMaximumLength();
         string memory cleartext =
             "asfsafsfsafsafasdfasfdsakfjdsakfjasdlkfajsdlfsdlfkasdfjdjasfhasdljhfdaslkfjsda;kfjasdklfjasdklfjasd;ladlkfjasdfad;flksadjf;lkasdjf;lsadsdlsdlkfjas;dlkfjas;dlkfjsad;lkfjsad;lda;lkfj;kasjf;klsadjf;lsadsdlkfjasd;lkfjsad;lfkajsd;flkasdjf;lsdkfjas;lfkasdflkasdf;laskfj;asldkfjsad;lfs;lf;flksajf;lk"; // solhint-disable-line
         orb.invokeWithHash(keccak256(bytes(cleartext)));

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1170,7 +1170,7 @@ contract ForeclosureTimeTest is OrbTestBase {
     }
 }
 
-contract TriggerWithCleartextTest is OrbTestBase {
+contract InvokeWithCleartextTest is OrbTestBase {
     event Triggered(address indexed from, uint256 indexed triggerId, bytes32 contentHash, uint256 time);
     event CleartextRecorded(uint256 indexed triggerId, string cleartext);
 
@@ -1180,7 +1180,7 @@ contract TriggerWithCleartextTest is OrbTestBase {
             "asfsafsfsafsafasdfasfdsakfjdsakfjasdlkfajsdlfsdlfkasdfjdjasfhasdljhfdaslkfjsda;kfjasdklfjasdklfjasd;ladlkfjasdfad;flksadjf;lkasdjf;lsadsdlsdlkfjas;dlkfjas;dlkfjsad;lkfjsad;lda;lkfj;kasjf;klsadjf;lsadsdlkfjasd;lkfjsad;lfkajsd;flkasdjf;lsdkfjas;lfkasdflkasdf;laskfj;asldkfjsad;lfs;lf;flksajf;lk"; // solhint-disable-line
         uint256 length = bytes(text).length;
         vm.expectRevert(abi.encodeWithSelector(Orb.CleartextTooLong.selector, length, max));
-        orb.triggerWithCleartext(text);
+        orb.invokeWithCleartext(text);
     }
 
     function test_callsTriggerHashCorrectly() public {
@@ -1191,7 +1191,7 @@ contract TriggerWithCleartextTest is OrbTestBase {
         vm.expectEmit(true, true, false, true);
         emit Triggered(user, 0, keccak256(abi.encodePacked(text)), block.timestamp);
         vm.prank(user);
-        orb.triggerWithCleartext(text);
+        orb.invokeWithCleartext(text);
     }
 }
 

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -1195,7 +1195,7 @@ contract InvokeWithCleartextTest is OrbTestBase {
     }
 }
 
-contract TriggerWthHashTest is OrbTestBase {
+contract InvokeWthHashTest is OrbTestBase {
     event Triggered(address indexed from, uint256 indexed triggerId, bytes32 contentHash, uint256 time);
 
     function test_revertWhen_NotHolder() public {

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -48,7 +48,7 @@ contract OrbTestBase is Test {
 
     function effectiveFundsOf(address user_) public view returns (uint256) {
         uint256 unadjustedFunds = orb.fundsOf(user_);
-        address holder = orb.ownerOf(orb.workaround_orbId());
+        address holder = orb.ownerOf(orb.workaround_tokenId());
 
         if (user_ == orb.owner()) {
             return unadjustedFunds;
@@ -74,7 +74,7 @@ contract OrbTestBase is Test {
 contract InitialStateTest is OrbTestBase {
     // Test that the initial state is correct
     function test_initialState() public {
-        assertEq(address(orb), orb.ownerOf(orb.workaround_orbId()));
+        assertEq(address(orb), orb.ownerOf(orb.workaround_tokenId()));
         assertFalse(orb.auctionRunning());
         assertEq(orb.owner(), address(this));
         assertEq(orb.beneficiary(), address(0xC0FFEE));
@@ -107,7 +107,7 @@ contract InitialStateTest is OrbTestBase {
         assertEq(orb.FEE_DENOMINATOR(), 10000);
         assertEq(orb.HOLDER_TAX_PERIOD(), 365 days);
 
-        assertEq(orb.workaround_orbId(), 69);
+        assertEq(orb.workaround_tokenId(), 69);
         assertEq(orb.workaround_infinity(), type(uint256).max);
         assertEq(orb.workaround_maxPrice(), 2 ** 128);
         assertEq(orb.workaround_baseUrl(), "https://static.orb.land/orb/");
@@ -117,7 +117,7 @@ contract InitialStateTest is OrbTestBase {
 contract TransfersRevertTest is OrbTestBase {
     function test_transfersRevert() public {
         address newOwner = address(0xBEEF);
-        uint256 id = orb.workaround_orbId();
+        uint256 id = orb.workaround_tokenId();
         vm.expectRevert(Orb.TransferringNotSupported.selector);
         orb.transferFrom(address(this), newOwner, id);
         vm.expectRevert(Orb.TransferringNotSupported.selector);
@@ -418,7 +418,7 @@ contract FinalizeAuctionTest is OrbTestBase {
         // storage that persists
         assertEq(address(orb).balance, funds);
         assertEq(orb.fundsOf(beneficiary), amount);
-        assertEq(orb.ownerOf(orb.workaround_orbId()), user);
+        assertEq(orb.ownerOf(orb.workaround_tokenId()), user);
         assertEq(orb.lastSettlementTime(), block.timestamp);
         assertEq(orb.lastInvocationTime(), block.timestamp - orb.cooldown());
         assertEq(orb.fundsOf(user), funds - amount);
@@ -969,7 +969,7 @@ contract PurchaseTest is OrbTestBase {
         vm.expectEmit(true, true, false, false);
         emit Purchase(owner, user, bidAmount);
         vm.expectEmit(true, true, true, false);
-        emit Transfer(owner, user, orb.workaround_orbId());
+        emit Transfer(owner, user, orb.workaround_tokenId());
         // The Orb is purchased with purchaseAmount
         // It uses both the existing funds of the user and the funds
         // that the user transfers when calling `purchase()`
@@ -1004,7 +1004,7 @@ contract PurchaseTest is OrbTestBase {
         vm.expectEmit(true, true, false, true);
         emit Purchase(user, user2, bidAmount);
         vm.expectEmit(true, true, true, false);
-        emit Transfer(user, user2, orb.workaround_orbId());
+        emit Transfer(user, user2, orb.workaround_tokenId());
         // The Orb is purchased with purchaseAmount
         // It uses both the existing funds of the user and the funds
         // that the user transfers when calling `purchase()`
@@ -1044,7 +1044,7 @@ contract PurchaseTest is OrbTestBase {
         vm.expectEmit(true, true, false, true);
         emit Purchase(user, user2, bidAmount);
         vm.expectEmit(true, true, true, false);
-        emit Transfer(user, user2, orb.workaround_orbId());
+        emit Transfer(user, user2, orb.workaround_tokenId());
         // The Orb is purchased with purchaseAmount
         // It uses both the existing funds of the user and the funds
         // that the user transfers when calling `purchase()`
@@ -1071,7 +1071,7 @@ contract RelinquishmentTest is OrbTestBase {
 
         vm.prank(user);
         orb.relinquish();
-        assertEq(orb.ownerOf(orb.workaround_orbId()), address(orb));
+        assertEq(orb.ownerOf(orb.workaround_tokenId()), address(orb));
     }
 
     function test_revertsIfHolderInsolvent() public {
@@ -1083,7 +1083,7 @@ contract RelinquishmentTest is OrbTestBase {
         vm.warp(block.timestamp - 1300 days);
         vm.prank(user);
         orb.relinquish();
-        assertEq(orb.ownerOf(orb.workaround_orbId()), address(orb));
+        assertEq(orb.ownerOf(orb.workaround_tokenId()), address(orb));
     }
 
     function test_settlesFirst() public {
@@ -1101,7 +1101,7 @@ contract RelinquishmentTest is OrbTestBase {
     function test_succeedsCorrectly() public {
         makeHolderAndWarp(user, 1 ether);
         vm.prank(user);
-        assertEq(orb.ownerOf(orb.workaround_orbId()), user);
+        assertEq(orb.ownerOf(orb.workaround_tokenId()), user);
         vm.expectEmit(true, true, false, false);
         emit Foreclosure(user, true);
         vm.expectEmit(true, false, false, true);
@@ -1109,7 +1109,7 @@ contract RelinquishmentTest is OrbTestBase {
         emit Withdrawal(user, effectiveFunds);
         vm.prank(user);
         orb.relinquish();
-        assertEq(orb.ownerOf(orb.workaround_orbId()), address(orb));
+        assertEq(orb.ownerOf(orb.workaround_tokenId()), address(orb));
         assertEq(orb.price(), 0);
     }
 }
@@ -1125,7 +1125,7 @@ contract ForecloseTest is OrbTestBase {
         vm.warp(block.timestamp + 100000 days);
         vm.prank(user2);
         orb.foreclose();
-        assertEq(orb.ownerOf(orb.workaround_orbId()), address(orb));
+        assertEq(orb.ownerOf(orb.workaround_tokenId()), address(orb));
     }
 
     event Foreclosure(address indexed formerHolder, bool indexed voluntary);
@@ -1147,9 +1147,9 @@ contract ForecloseTest is OrbTestBase {
         vm.warp(block.timestamp + 10000 days);
         vm.expectEmit(true, true, false, false);
         emit Foreclosure(user, false);
-        assertEq(orb.ownerOf(orb.workaround_orbId()), user);
+        assertEq(orb.ownerOf(orb.workaround_tokenId()), user);
         orb.foreclose();
-        assertEq(orb.ownerOf(orb.workaround_orbId()), address(orb));
+        assertEq(orb.ownerOf(orb.workaround_tokenId()), address(orb));
         assertEq(orb.price(), 0);
     }
 }

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -82,6 +82,7 @@ contract InitialStateTest is OrbTestBase {
         assertEq(orb.cleartextMaximumLength(), 280);
 
         assertEq(orb.price(), 0);
+        assertEq(orb.holderTaxNumerator(), 1_000);
         assertEq(orb.lastInvocationTime(), 0);
         assertEq(orb.invocationCount(), 0);
 

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -262,7 +262,7 @@ contract BidTest is OrbTestBase {
         assertEq(orb.price(), orb.workaround_maxPrice());
     }
 
-    event NewBid(address indexed from, uint256 price);
+    event AuctionBid(address indexed bidder, uint256 bid);
 
     function test_bidSetsCorrectState() public {
         orb.startAuction();
@@ -275,7 +275,7 @@ contract BidTest is OrbTestBase {
         uint256 auctionEndTime = orb.auctionEndTime();
 
         vm.expectEmit(true, false, false, true);
-        emit NewBid(user, amount);
+        emit AuctionBid(user, amount);
         prankAndBid(user, amount);
 
         assertEq(orb.leadingBid(), amount);
@@ -303,7 +303,7 @@ contract BidTest is OrbTestBase {
             fundsOfUser[bidder] += funds;
 
             vm.expectEmit(true, false, false, true);
-            emit NewBid(bidder, amount);
+            emit AuctionBid(bidder, amount);
             prankAndBid(bidder, amount);
             contractBalance += funds;
 

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -482,7 +482,7 @@ contract EffectiveFundsOfTest is OrbTestBase {
 }
 
 contract DepositTest is OrbTestBase {
-    event Deposit(address indexed user, uint256 amount);
+    event Deposit(address indexed depositor, uint256 amount);
 
     function test_depositRandomUser() public {
         assertEq(orb.fundsOf(user), 0);

--- a/test/harness/OrbHarness.sol
+++ b/test/harness/OrbHarness.sol
@@ -10,8 +10,6 @@ contract OrbHarness is
         1 days, // auctionMinimumDuration
         30 minutes, // auctionBidExtension
         address(0xC0FFEE), // beneficiary
-        1000, // holderTaxNumerator
-        1000, // royaltyNumerator
         0.1 ether, // auctionStartingPrice
         0.1 ether // auctionMinimumBidStep
     )

--- a/test/harness/OrbHarness.sol
+++ b/test/harness/OrbHarness.sol
@@ -33,12 +33,12 @@ contract OrbHarness is
         return BASE_URL;
     }
 
-    function workaround_setWinningBidder(address bidder) public {
-        winningBidder = bidder;
+    function workaround_setLeadingBidder(address bidder) public {
+        leadingBidder = bidder;
     }
 
-    function workaround_setWinningBid(uint256 bid) public {
-        winningBid = bid;
+    function workaround_setLeadingBid(uint256 bid) public {
+        leadingBid = bid;
     }
 
     function workaround_setPrice(uint256 _price) public {

--- a/test/harness/OrbHarness.sol
+++ b/test/harness/OrbHarness.sol
@@ -6,12 +6,13 @@ import {Orb} from "src/Orb.sol";
 /* solhint-disable func-name-mixedcase */
 contract OrbHarness is
     Orb(
+        69, // tokenId
         7 days, // cooldown
         address(0xC0FFEE) // beneficiary
     )
 {
-    function workaround_orbId() public pure returns (uint256) {
-        return TOKEN_ID;
+    function workaround_tokenId() public view returns (uint256) {
+        return tokenId;
     }
 
     function workaround_infinity() public pure returns (uint256) {
@@ -43,7 +44,7 @@ contract OrbHarness is
     }
 
     function workaround_setOrbHolder(address holder) public {
-        _transferOrb(ownerOf(TOKEN_ID), holder);
+        _transferOrb(ownerOf(tokenId), holder);
     }
 
     function workaround_owedSinceLastSettlement() public view returns (uint256) {

--- a/test/harness/OrbHarness.sol
+++ b/test/harness/OrbHarness.sol
@@ -7,7 +7,6 @@ import {Orb} from "src/Orb.sol";
 contract OrbHarness is
     Orb(
         7 days, // cooldown
-        7 days, // responseFlaggingPeriod
         1 days, // auctionMinimumDuration
         30 minutes, // auctionBidExtension
         address(0xC0FFEE), // beneficiary

--- a/test/harness/OrbHarness.sol
+++ b/test/harness/OrbHarness.sol
@@ -12,7 +12,7 @@ contract OrbHarness is
         30 minutes, // auctionBidExtension
         address(0xC0FFEE), // beneficiary
         1000, // holderTaxNumerator
-        1000, // saleRoyaltiesNumerator
+        1000, // royaltyNumerator
         0.1 ether, // auctionStartingPrice
         0.1 ether // auctionMinimumBidStep
     )

--- a/test/harness/OrbHarness.sol
+++ b/test/harness/OrbHarness.sol
@@ -23,8 +23,8 @@ contract OrbHarness is
         return MAX_PRICE;
     }
 
-    function workaround_baseUrl() public pure returns (string memory) {
-        return BASE_URL;
+    function workaround_baseUrl() public view returns (string memory) {
+        return baseURL;
     }
 
     function workaround_setLeadingBidder(address bidder) public {

--- a/test/harness/OrbHarness.sol
+++ b/test/harness/OrbHarness.sol
@@ -7,7 +7,6 @@ import {Orb} from "src/Orb.sol";
 contract OrbHarness is
     Orb(
         69, // tokenId
-        7 days, // cooldown
         address(0xC0FFEE) // beneficiary
     )
 {

--- a/test/harness/OrbHarness.sol
+++ b/test/harness/OrbHarness.sol
@@ -7,11 +7,7 @@ import {Orb} from "src/Orb.sol";
 contract OrbHarness is
     Orb(
         7 days, // cooldown
-        1 days, // auctionMinimumDuration
-        30 minutes, // auctionBidExtension
-        address(0xC0FFEE), // beneficiary
-        0.1 ether, // auctionStartingPrice
-        0.1 ether // auctionMinimumBidStep
+        address(0xC0FFEE) // beneficiary
     )
 {
     function workaround_orbId() public pure returns (uint256) {


### PR DESCRIPTION

- `startingPrice` → `auctionStartingPrice`
- `minimumBidStep` → `auctionMinimumBidStep`
- `minimumAuctionDuration` → `auctionMinimumDuration`
- `bidAuctionExtension` → `auctionBidExtension`
- `startTime` → `auctionStartTime`
- `endTime` → `auctionEndTime`
- `winningBid` → `leadingBid`
- `winningBidder` → `leadingBidder`
- `MAX_CLEARTEXT_LENGTH` → `CLEARTEXT_MAXIMUM_LENGTH`
- `saleRoyaltiesNumerator` → `royaltyNumerator`
- `exit()` → `relinquish()`
- `lastTriggerTime` → `lastInvocationTime`
- `triggers` → `invocations`
- `triggersCount` → `invocationCount`
- `triggerWithCleartext()` → `invokeWithCleartext()`
- `triggerWithHash()` → `invokeWithHash()`
- `recordTriggerCleartext()` → `recordInvocationCleartext()`
- `AuctionStarted(uint256 auctionStartTime, uint256 auctionEndTime)`
- `AuctionBid(address indexed bidder, uint256 bid)`
- `AuctionExtended(uint256 newAuctionEndTime)`
- `AuctionFinalized(address indexed winner, uint256 winningBid)`
- `Deposit(address indexed depositor, uint256 amount)`
- `Settlement(address indexed holder, address indexed beneficiary, uint256 amount)`
- `PriceUpdated(uint256 previousPrice, uint256 newPrice)`
- `Purchase(address indexed seller, address indexed buyer, uint256 price)`
- `Foreclosure(address indexed formerHolder, bool indexed voluntary)`
- `Invocation(address indexed invoker, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp)`
- `Response(address indexed responder, uint256 indexed invocationId, bytes32 contentHash, uint256 timestamp)`
- `CleartextRecorded(uint256 indexed invocationId, string cleartext)`
- `ResponseFlagging(address indexed flagger, uint256 indexed invocationId)`
- `CleartextTooLong(uint256 cleartextLength, uint256 cleartextMaxLength)`
- `CleartextHashMismatch(bytes32 cleartextHash, bytes32 recordedContentHash)`
- `InvocationNotFound(uint256 invocationId)`
- `ResponseNotFound(uint256 invocationId)`
- `ResponseExists(uint256 invocationId)`
- `FlaggingPeriodExpired(uint256 invocationId, uint256 currentTimeValue, uint256 timeValueLimit)`
- `ResponseAlreadyFlagged(uint256 invocationId)`
- Unify event names as nouns
    - `AuctionStart`
    - `AuctionExtension`
    - `AuctionFinalization`
    - `PriceUpdate`
    - `CleartextRecording`
- Review argument names
- triggerId, other internal variables
- a trigger, to trigger in comments → an invocation, to invoke
- Orb capitalization
- issuer in comments → creator
- fixing winning, royalties in comments

---

- *Note:* creator is still `owner()` in contract, sometimes called issuer inheriting from OZ contract
- *Note:* orb owner is still called holder in contract and read as `ownerOf(tokenId)`, inheriting from OZ contract