### PR TITLE
onlyCreatorControlled checks that auction is not running

### DIFF
--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -244,6 +244,9 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
         if (address(this) != ERC721.ownerOf(tokenId) && owner() != ERC721.ownerOf(tokenId)) {
             revert CreatorDoesNotControlOrb();
         }
+        if (auctionEndTime > 0) {
+            revert AuctionRunning();
+        }
         _;
     }
 

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -7,7 +7,7 @@ import {OrbHarness} from "./harness/OrbHarness.sol";
 import {Orb} from "src/Orb.sol";
 import {IOrb} from "src/IOrb.sol";
 
-/* solhint-disable func-name-mixedcase */
+/* solhint-disable func-name-mixedcase,private-vars-leading-underscore */
 contract OrbTestBase is Test {
     OrbHarness internal orb;
 
@@ -155,7 +155,18 @@ contract SwearOathTest is OrbTestBase {
         vm.expectRevert("Ownable: caller is not the owner");
         orb.swearOath(keccak256(abi.encodePacked("test oath")), 100);
 
-        makeHolderAndWarp(user, 1 ether);
+        vm.prank(owner);
+        orb.startAuction();
+
+        vm.prank(owner);
+        vm.expectRevert(IOrb.AuctionRunning.selector);
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 100);
+
+        prankAndBid(user, 1 ether);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+        vm.warp(block.timestamp + 30 days);
+
         vm.prank(owner);
         vm.expectRevert(IOrb.CreatorDoesNotControlOrb.selector);
         orb.swearOath(keccak256(abi.encodePacked("test oath")), 100);
@@ -231,7 +242,18 @@ contract SettingAuctionParametersTest is OrbTestBase {
         vm.expectRevert("Ownable: caller is not the owner");
         orb.setAuctionParameters(0.2 ether, 0.2 ether, 2 days, 10 minutes);
 
-        makeHolderAndWarp(user, 1 ether);
+        vm.prank(owner);
+        orb.startAuction();
+
+        vm.prank(owner);
+        vm.expectRevert(IOrb.AuctionRunning.selector);
+        orb.setAuctionParameters(0.2 ether, 0.2 ether, 2 days, 10 minutes);
+
+        prankAndBid(user, 1 ether);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+        vm.warp(block.timestamp + 30 days);
+
         vm.prank(owner);
         vm.expectRevert(IOrb.CreatorDoesNotControlOrb.selector);
         orb.setAuctionParameters(0.2 ether, 0.2 ether, 2 days, 10 minutes);
@@ -286,7 +308,18 @@ contract SettingFeesTest is OrbTestBase {
         vm.expectRevert("Ownable: caller is not the owner");
         orb.setFees(10_000, 10_000);
 
-        makeHolderAndWarp(user, 1 ether);
+        vm.prank(owner);
+        orb.startAuction();
+
+        vm.prank(owner);
+        vm.expectRevert(IOrb.AuctionRunning.selector);
+        orb.setFees(10_000, 10_000);
+
+        prankAndBid(user, 1 ether);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+        vm.warp(block.timestamp + 30 days);
+
         vm.prank(owner);
         vm.expectRevert(IOrb.CreatorDoesNotControlOrb.selector);
         orb.setFees(10_000, 10_000);
@@ -329,7 +362,18 @@ contract SettingCooldownTest is OrbTestBase {
         vm.expectRevert("Ownable: caller is not the owner");
         orb.setCooldown(1 days);
 
-        makeHolderAndWarp(user, 1 ether);
+        vm.prank(owner);
+        orb.startAuction();
+
+        vm.prank(owner);
+        vm.expectRevert(IOrb.AuctionRunning.selector);
+        orb.setCooldown(1 days);
+
+        prankAndBid(user, 1 ether);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+        vm.warp(block.timestamp + 30 days);
+
         vm.prank(owner);
         vm.expectRevert(IOrb.CreatorDoesNotControlOrb.selector);
         orb.setCooldown(1 days);
@@ -359,7 +403,18 @@ contract SettingCleartextMaximumLengthTest is OrbTestBase {
         vm.expectRevert("Ownable: caller is not the owner");
         orb.setCleartextMaximumLength(1);
 
-        makeHolderAndWarp(user, 1 ether);
+        vm.prank(owner);
+        orb.startAuction();
+
+        vm.prank(owner);
+        vm.expectRevert(IOrb.AuctionRunning.selector);
+        orb.setCleartextMaximumLength(1);
+
+        prankAndBid(user, 1 ether);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+        vm.warp(block.timestamp + 30 days);
+
         vm.prank(owner);
         vm.expectRevert(IOrb.CreatorDoesNotControlOrb.selector);
         orb.setCleartextMaximumLength(1);


### PR DESCRIPTION
Addresses audit High 00 (self-reported after audit)

## High 00 (client reported) - Malicious Orb owners can steal from auction bidders by adjusting Orb parameters mid-auction

The Orb allows the creator to set Orb parameters while the Orb is under their control, this being defined as Orb being held by the creator or Orb contract. However, this definition does not include checking if the auction is running.

By adjusting fee parameters (particularly Harberger tax, `holderTaxNumerator`) while the auction is running, Orb creator can drain winning bidder's funds in a very short time.

Planned fix: to check that auction has not been started (`auctionEndTime` > 0) in the `onlyCreatorControlled` modifier.