### PR TITLE
Requiring critical orb parameters when purchasing

### DIFF
--- a/src/IOrb.sol
+++ b/src/IOrb.sol
@@ -85,7 +85,7 @@ interface IOrb is IERC165 {
     error InsufficientFunds(uint256 fundsAvailable, uint256 fundsRequired);
 
     // Purchasing Errors
-    error CurrentPriceIncorrect(uint256 priceProvided, uint256 currentPrice);
+    error CurrentValueIncorrect(uint256 valueProvided, uint256 currentValue);
     error PurchasingNotPermitted();
     error InvalidNewPrice(uint256 priceProvided);
 
@@ -175,7 +175,14 @@ interface IOrb is IERC165 {
     // Purchasing Functions
     function listWithPrice(uint256 listingPrice) external;
     function setPrice(uint256 newPrice) external;
-    function purchase(uint256 currentPrice, uint256 newPrice) external payable;
+    function purchase(
+        uint256 newPrice,
+        uint256 currentPrice,
+        uint256 currentHolderTaxNumerator,
+        uint256 currentRoyaltyNumerator,
+        uint256 currentCooldown,
+        uint256 currentCleartextMaximumLength
+    ) external payable;
 
     // Orb Ownership Functions
     function relinquish() external;

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -725,9 +725,28 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
     ///          royalty payments. Does not allow purchasing from yourself. Emits `PriceUpdate` and `Purchase`.
     /// @param   currentPrice  Current price, to prevent front-running.
     /// @param   newPrice      New price to use after the purchase.
-    function purchase(uint256 currentPrice, uint256 newPrice) external payable onlyHolderHeld onlyHolderSolvent {
+    function purchase(
+        uint256 newPrice,
+        uint256 currentPrice,
+        uint256 currentHolderTaxNumerator,
+        uint256 currentRoyaltyNumerator,
+        uint256 currentCooldown,
+        uint256 currentCleartextMaximumLength
+    ) external payable onlyHolderHeld onlyHolderSolvent {
         if (currentPrice != price) {
-            revert CurrentPriceIncorrect(currentPrice, price);
+            revert CurrentValueIncorrect(currentPrice, price);
+        }
+        if (currentHolderTaxNumerator != holderTaxNumerator) {
+            revert CurrentValueIncorrect(currentHolderTaxNumerator, holderTaxNumerator);
+        }
+        if (currentRoyaltyNumerator != royaltyNumerator) {
+            revert CurrentValueIncorrect(currentRoyaltyNumerator, royaltyNumerator);
+        }
+        if (currentCooldown != cooldown) {
+            revert CurrentValueIncorrect(currentCooldown, cooldown);
+        }
+        if (currentCleartextMaximumLength != cleartextMaximumLength) {
+            revert CurrentValueIncorrect(currentCleartextMaximumLength, cleartextMaximumLength);
         }
 
         if (lastSettlementTime >= block.timestamp) {

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -130,7 +130,7 @@ contract SupportsInterfaceTest is OrbTestBase {
         assert(orb.supportsInterface(0x01ffc9a7)); // ERC165 Interface ID for ERC165
         assert(orb.supportsInterface(0x80ac58cd)); // ERC165 Interface ID for ERC721
         assert(orb.supportsInterface(0x5b5e139f)); // ERC165 Interface ID for ERC721Metadata
-        assert(orb.supportsInterface(0x841be724)); // ERC165 Interface ID for Orb
+        assert(orb.supportsInterface(0xa46de429)); // ERC165 Interface ID for Orb
     }
 }
 
@@ -1190,7 +1190,7 @@ contract PurchaseTest is OrbTestBase {
     function test_revertsIfHeldByContract() public {
         vm.prank(user);
         vm.expectRevert(IOrb.ContractHoldsOrb.selector);
-        orb.purchase(0, 100);
+        orb.purchase(100, 0, 10_00, 10_00, 7 days, 280);
     }
 
     function test_revertsIfHolderInsolvent() public {
@@ -1198,7 +1198,7 @@ contract PurchaseTest is OrbTestBase {
         vm.warp(block.timestamp + 1300 days);
         vm.prank(user2);
         vm.expectRevert(IOrb.HolderInsolvent.selector);
-        orb.purchase(0, 100);
+        orb.purchase(100, 1 ether, 10_00, 10_00, 7 days, 280);
     }
 
     function test_purchaseSettlesFirst() public {
@@ -1206,7 +1206,7 @@ contract PurchaseTest is OrbTestBase {
         // after making `user` the current holder of the Orb, `makeHolderAndWarp(user, )` warps 30 days into the future
         assertEq(orb.lastSettlementTime(), block.timestamp - 30 days);
         vm.prank(user2);
-        orb.purchase{value: 1.1 ether}(1 ether, 2 ether);
+        orb.purchase{value: 1.1 ether}(2 ether, 1 ether, 10_00, 10_00, 7 days, 280);
         assertEq(orb.lastSettlementTime(), block.timestamp);
     }
 
@@ -1215,34 +1215,57 @@ contract PurchaseTest is OrbTestBase {
         vm.deal(beneficiary, 1.1 ether);
         vm.prank(beneficiary);
         vm.expectRevert(abi.encodeWithSelector(IOrb.BeneficiaryDisallowed.selector));
-        orb.purchase{value: 1.1 ether}(1 ether, 3 ether);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 10_00, 10_00, 7 days, 280);
 
         // does not revert
         assertEq(orb.lastSettlementTime(), block.timestamp - 30 days);
         vm.prank(user2);
-        orb.purchase{value: 1.1 ether}(1 ether, 3 ether);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 10_00, 10_00, 7 days, 280);
         assertEq(orb.lastSettlementTime(), block.timestamp);
     }
 
     function test_revertsIfWrongCurrentPrice() public {
         makeHolderAndWarp(user, 1 ether);
         vm.prank(user2);
-        vm.expectRevert(abi.encodeWithSelector(IOrb.CurrentPriceIncorrect.selector, 2 ether, 1 ether));
-        orb.purchase{value: 1.1 ether}(2 ether, 3 ether);
+        vm.expectRevert(abi.encodeWithSelector(IOrb.CurrentValueIncorrect.selector, 2 ether, 1 ether));
+        orb.purchase{value: 1.1 ether}(3 ether, 2 ether, 10_00, 10_00, 7 days, 280);
+    }
+
+    function test_revertsIfWrongCurrentValues() public {
+        orb.listWithPrice(1 ether);
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(IOrb.CurrentValueIncorrect.selector, 20_00, 10_00));
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 20_00, 10_00, 7 days, 280);
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(IOrb.CurrentValueIncorrect.selector, 30_00, 10_00));
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 10_00, 30_00, 7 days, 280);
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(IOrb.CurrentValueIncorrect.selector, 8 days, 7 days));
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 10_00, 10_00, 8 days, 280);
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(IOrb.CurrentValueIncorrect.selector, 140, 280));
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 10_00, 10_00, 7 days, 140);
+
+        vm.prank(user);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 10_00, 10_00, 7 days, 280);
     }
 
     function test_revertsIfIfAlreadyHolder() public {
         makeHolderAndWarp(user, 1 ether);
         vm.expectRevert(IOrb.AlreadyHolder.selector);
         vm.prank(user);
-        orb.purchase{value: 1.1 ether}(1 ether, 3 ether);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 10_00, 10_00, 7 days, 280);
     }
 
     function test_revertsIfInsufficientFunds() public {
         makeHolderAndWarp(user, 1 ether);
         vm.expectRevert(abi.encodeWithSelector(IOrb.InsufficientFunds.selector, 1 ether - 1, 1 ether));
         vm.prank(user2);
-        orb.purchase{value: 1 ether - 1}(1 ether, 3 ether);
+        orb.purchase{value: 1 ether - 1}(3 ether, 1 ether, 10_00, 10_00, 7 days, 280);
     }
 
     function test_revertsIfPurchasingAfterSetPrice() public {
@@ -1251,7 +1274,7 @@ contract PurchaseTest is OrbTestBase {
         orb.setPrice(0);
         vm.expectRevert(abi.encodeWithSelector(IOrb.PurchasingNotPermitted.selector));
         vm.prank(user2);
-        orb.purchase(0, 1 ether);
+        orb.purchase(1 ether, 0, 10_00, 10_00, 7 days, 280);
     }
 
     event Purchase(address indexed seller, address indexed buyer, uint256 price);
@@ -1280,7 +1303,7 @@ contract PurchaseTest is OrbTestBase {
         // The Orb is purchased with purchaseAmount
         // It uses both the existing funds of the user and the funds
         // that the user transfers when calling `purchase()`
-        orb.purchase{value: purchaseAmount + 1}(bidAmount, newPrice);
+        orb.purchase{value: purchaseAmount + 1}(newPrice, bidAmount, 10_00, 10_00, 7 days, 280);
         uint256 beneficiaryRoyalty = bidAmount;
         assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty);
         assertEq(orb.fundsOf(owner), ownerBefore);
@@ -1322,7 +1345,7 @@ contract PurchaseTest is OrbTestBase {
         // It uses both the existing funds of the user and the funds
         // that the user transfers when calling `purchase()`
         vm.prank(user2);
-        orb.purchase{value: purchaseAmount + 1}(bidAmount, newPrice);
+        orb.purchase{value: purchaseAmount + 1}(newPrice, bidAmount, 10_00, 10_00, 7 days, 280);
         uint256 beneficiaryRoyalty = ((bidAmount * orb.royaltyNumerator()) / orb.feeDenominator());
         assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty + expectedSettlement);
         assertEq(orb.fundsOf(user), userBefore + (bidAmount - beneficiaryRoyalty - expectedSettlement));
@@ -1371,7 +1394,7 @@ contract PurchaseTest is OrbTestBase {
         // that the user transfers when calling `purchase()`
         // We bound the purchaseAmount to be higher than the current price (bidAmount)
         vm.prank(user2);
-        orb.purchase{value: purchaseAmount}(bidAmount, newPrice);
+        orb.purchase{value: purchaseAmount}(newPrice, bidAmount, 10_00, 10_00, 7 days, 280);
         uint256 beneficiaryRoyalty = ((bidAmount * orb.royaltyNumerator()) / orb.feeDenominator());
         assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty + expectedSettlement);
         assertEq(orb.fundsOf(user), userBefore + (bidAmount - beneficiaryRoyalty - expectedSettlement));
@@ -1735,7 +1758,7 @@ contract FlagResponseTest is OrbTestBase {
         orb.respond(1, response);
 
         vm.startPrank(user2);
-        orb.purchase{value: 3 ether}(1 ether, 2 ether);
+        orb.purchase{value: 3 ether}(2 ether, 1 ether, 10_00, 10_00, 7 days, 280);
         vm.expectRevert(
             abi.encodeWithSelector(IOrb.FlaggingPeriodExpired.selector, 1, orb.holderReceiveTime(), block.timestamp)
         );


### PR DESCRIPTION
Addresses audit High 01 - Malicious Orb owners can steal from holders by front running the purchase transaction when purchasing the Orb from owner

Adds `currentHolderTaxNumerator`, `currentRoyaltyNumerator`, `currentCooldown` and `currentCleartextMaximumLength` parameters to the `purchase` function and check their value match in the same way as `currentPrice` parameter is checked.
