### PR TITLE
Settling when withdrawing all for beneficiary

### DIFF
--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -588,6 +588,9 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
     /// @notice  Function to withdraw all beneficiary funds on the contract.
     /// @dev     Allowed for anyone at any time, does not use `msg.sender` in its execution.
     function withdrawAllForBeneficiary() external {
+        if (ERC721.ownerOf(tokenId) != address(this)) {
+            _settle();
+        }
         _withdraw(beneficiary, fundsOf[beneficiary]);
     }
 

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -973,9 +973,6 @@ contract WithdrawTest is OrbTestBase {
         vm.prank(user);
         vm.expectEmit(true, true, false, true);
         emit Settlement(user, beneficiary, transferableToBeneficiary);
-        orb.settle();
-
-        assertEq(orb.fundsOf(beneficiary), beneficiaryFunds + transferableToBeneficiary);
 
         vm.expectEmit(true, false, false, true);
         emit Withdrawal(beneficiary, beneficiaryFunds + transferableToBeneficiary);
@@ -985,6 +982,50 @@ contract WithdrawTest is OrbTestBase {
         assertEq(orb.fundsOf(beneficiary), 0);
         assertEq(orb.lastSettlementTime(), block.timestamp);
         assertEq(beneficiary.balance, initialBalance + beneficiaryEffective);
+    }
+
+    function test_withdrawAllForBeneficiaryWhenContractOwned() public {
+        makeHolderAndWarp(user, 1 ether);
+        vm.prank(user);
+        orb.relinquish();
+
+        uint256 beneficiaryFunds = orb.fundsOf(beneficiary);
+        uint256 initialBalance = beneficiary.balance;
+        uint256 settlementTime = block.timestamp;
+
+        vm.warp(block.timestamp + 30 days);
+
+        // expectNotEmit Settlement
+        vm.expectEmit(true, false, false, true);
+        emit Withdrawal(beneficiary, beneficiaryFunds);
+        orb.withdrawAllForBeneficiary();
+
+        assertEq(orb.fundsOf(beneficiary), 0);
+        assertEq(orb.lastSettlementTime(), settlementTime);
+        assertEq(beneficiary.balance, initialBalance + beneficiaryFunds);
+    }
+
+    function test_withdrawAllForBeneficiaryWhenCreatorOwned() public {
+        makeHolderAndWarp(user, 1 ether);
+        vm.prank(user);
+        orb.relinquish();
+        vm.prank(owner);
+        orb.listWithPrice(1 ether);
+
+        uint256 beneficiaryFunds = orb.fundsOf(beneficiary);
+        uint256 initialBalance = beneficiary.balance;
+        uint256 settlementTime = block.timestamp;
+
+        vm.warp(block.timestamp + 30 days);
+
+        // expectNotEmit Settlement
+        vm.expectEmit(true, false, false, true);
+        emit Withdrawal(beneficiary, beneficiaryFunds);
+        orb.withdrawAllForBeneficiary();
+
+        assertEq(orb.fundsOf(beneficiary), 0);
+        assertEq(orb.lastSettlementTime(), settlementTime);
+        assertEq(beneficiary.balance, initialBalance + beneficiaryFunds);
     }
 
     function testFuzz_withdrawSettlesFirstIfHolder(uint256 bidAmount, uint256 withdrawAmount) public {


### PR DESCRIPTION
Addresses audit Low 01 - Beneficiary withdraw function might not withdraw all beneficiary's funds.

Calls `_settle()` in `withdrawAllForBeneficiary()`, if holder-held.