### PR TITLE
Renaming Holder to Keeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Auction + Harberger taxed ownership. Used by [orb.land](https://orb.land). Uses Forge toolkit for building and testing. The contract combines the following areas of functionality:
 
-- **Auction.** Allows the contract owner to start the Orb auction, determining the first owner of the Orb.
+- **Auction.** Allows the contract owner to start the Orb auction, determining the first Keeper of the Orb.
 - **Funds management.** Allows any user to deposit and withdraw funds. Funds are used to make auction bids and pay Harberger Tax.
-- **Harberger Tax.** Uses delayed accounting (settling) to allocate funds from the current owner to the contract beneficiary, based on the price set by the owner and tax rate.
-- **On-chain Orb Invocations.** Allows the owner to periodically invoke the Orb, requesting a response from the Orb creator.
+- **Harberger Tax.** Uses delayed accounting (settling) to allocate funds from the current Keeper to the contract beneficiary, based on the price set by the Keeper and tax rate.
+- **On-chain Orb Invocations.** Allows the Keeper to periodically invoke the Orb, requesting a response from the Orb creator.
 - **ERC-721 compatibility.** All transfers revert, but otherwise, the contract appears as supporting all ERC-721 functions.
 
 The contract is fully documented in NatSpec format.

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -2,10 +2,10 @@
 
 Auction + Harberger taxed ownership. Used by [orb.land](https://orb.land). Uses Forge toolkit for building and testing. The contract combines the following areas of functionality:
 
-- **Auction.** Allows the contract owner to start the Orb auction, determining the first owner of the Orb.
+- **Auction.** Allows the contract owner to start the Orb auction, determining the first Keeper of the Orb.
 - **Funds management.** Allows any user to deposit and withdraw funds. Funds are used to make auction bids and pay Harberger Tax.
-- **Harberger Tax.** Uses delayed accounting (settling) to allocate funds from the current owner to the contract beneficiary, based on the price set by the owner and tax rate.
-- **On-chain Orb Invocations.** Allows the owner to periodically invoke the Orb, requesting a response from the Orb creator.
+- **Harberger Tax.** Uses delayed accounting (settling) to allocate funds from the current Keeper to the contract beneficiary, based on the price set by the Keeper and tax rate.
+- **On-chain Orb Invocations.** Allows the Keeper to periodically invoke the Orb, requesting a response from the Orb creator.
 - **ERC-721 compatibility.** All transfers revert, but otherwise, the contract appears as supporting all ERC-721 functions.
 
 The contract is fully documented in NatSpec format.

--- a/docs/src/src/IOrb.sol/interface.IOrb.md
+++ b/docs/src/src/IOrb.sol/interface.IOrb.md
@@ -1,5 +1,5 @@
 # IOrb
-[Git Source](https://github.com/orbland/orb/blob/f37a4815190396d804787713635fa8c023271236/src/IOrb.sol)
+[Git Source](https://github.com/orbland/orb/blob/ede71e56991e5a4a14f114e02bbcc807493c9804/src/IOrb.sol)
 
 **Inherits:**
 IERC165
@@ -90,18 +90,18 @@ function fundsOf(address owner) external view returns (uint256);
 function lastSettlementTime() external view returns (uint256);
 ```
 
-### holderSolvent
+### keeperSolvent
 
 
 ```solidity
-function holderSolvent() external view returns (bool);
+function keeperSolvent() external view returns (bool);
 ```
 
-### holderTaxNumerator
+### keeperTaxNumerator
 
 
 ```solidity
-function holderTaxNumerator() external view returns (uint256);
+function keeperTaxNumerator() external view returns (uint256);
 ```
 
 ### feeDenominator
@@ -111,11 +111,11 @@ function holderTaxNumerator() external view returns (uint256);
 function feeDenominator() external view returns (uint256);
 ```
 
-### holderTaxPeriod
+### keeperTaxPeriod
 
 
 ```solidity
-function holderTaxPeriod() external view returns (uint256);
+function keeperTaxPeriod() external view returns (uint256);
 ```
 
 ### price
@@ -125,11 +125,11 @@ function holderTaxPeriod() external view returns (uint256);
 function price() external view returns (uint256);
 ```
 
-### holderReceiveTime
+### keeperReceiveTime
 
 
 ```solidity
-function holderReceiveTime() external view returns (uint256);
+function keeperReceiveTime() external view returns (uint256);
 ```
 
 ### royaltyNumerator
@@ -289,7 +289,7 @@ function setPrice(uint256 newPrice) external;
 function purchase(
     uint256 newPrice,
     uint256 currentPrice,
-    uint256 currentHolderTaxNumerator,
+    uint256 currentKeeperTaxNumerator,
     uint256 currentRoyaltyNumerator,
     uint256 currentCooldown,
     uint256 currentCleartextMaximumLength
@@ -375,7 +375,7 @@ function setAuctionParameters(
 
 
 ```solidity
-function setFees(uint256 newHolderTaxNumerator, uint256 newRoyaltyNumerator) external;
+function setFees(uint256 newKeeperTaxNumerator, uint256 newRoyaltyNumerator) external;
 ```
 
 ### setCooldown
@@ -438,7 +438,7 @@ event Withdrawal(address indexed recipient, uint256 indexed amount);
 ### Settlement
 
 ```solidity
-event Settlement(address indexed holder, address indexed beneficiary, uint256 indexed amount);
+event Settlement(address indexed keeper, address indexed beneficiary, uint256 indexed amount);
 ```
 
 ### PriceUpdate
@@ -456,13 +456,13 @@ event Purchase(address indexed seller, address indexed buyer, uint256 indexed pr
 ### Foreclosure
 
 ```solidity
-event Foreclosure(address indexed formerHolder);
+event Foreclosure(address indexed formerKeeper);
 ```
 
 ### Relinquishment
 
 ```solidity
-event Relinquishment(address indexed formerHolder);
+event Relinquishment(address indexed formerKeeper);
 ```
 
 ### Invocation
@@ -520,8 +520,8 @@ event AuctionParametersUpdate(
 
 ```solidity
 event FeesUpdate(
-    uint256 previousHolderTaxNumerator,
-    uint256 indexed newHolderTaxNumerator,
+    uint256 previousKeeperTaxNumerator,
+    uint256 indexed newKeeperTaxNumerator,
     uint256 previousRoyaltyNumerator,
     uint256 indexed newRoyaltyNumerator
 );
@@ -546,16 +546,16 @@ event CleartextMaximumLengthUpdate(uint256 previousCleartextMaximumLength, uint2
 error TransferringNotSupported();
 ```
 
-### AlreadyHolder
+### AlreadyKeeper
 
 ```solidity
-error AlreadyHolder();
+error AlreadyKeeper();
 ```
 
-### NotHolder
+### NotKeeper
 
 ```solidity
-error NotHolder();
+error NotKeeper();
 ```
 
 ### ContractHoldsOrb
@@ -612,16 +612,16 @@ error NotPermittedForLeadingBidder();
 error InsufficientBid(uint256 bidProvided, uint256 bidRequired);
 ```
 
-### HolderSolvent
+### KeeperSolvent
 
 ```solidity
-error HolderSolvent();
+error KeeperSolvent();
 ```
 
-### HolderInsolvent
+### KeeperInsolvent
 
 ```solidity
-error HolderInsolvent();
+error KeeperInsolvent();
 ```
 
 ### InsufficientFunds

--- a/docs/src/src/OrbPond.sol/contract.OrbPond.md
+++ b/docs/src/src/OrbPond.sol/contract.OrbPond.md
@@ -1,5 +1,5 @@
 # OrbPond
-[Git Source](https://github.com/orbland/orb/blob/f37a4815190396d804787713635fa8c023271236/src/OrbPond.sol)
+[Git Source](https://github.com/orbland/orb/blob/ede71e56991e5a4a14f114e02bbcc807493c9804/src/OrbPond.sol)
 
 **Inherits:**
 Ownable
@@ -75,7 +75,7 @@ function configureOrb(
     uint256 auctionMinimumBidStep,
     uint256 auctionMinimumDuration,
     uint256 auctionBidExtension,
-    uint256 holderTaxNumerator,
+    uint256 keeperTaxNumerator,
     uint256 royaltyNumerator,
     uint256 cooldown,
     uint256 cleartextMaximumLength
@@ -90,7 +90,7 @@ function configureOrb(
 |`auctionMinimumBidStep`|`uint256`|  Minimum difference between bids in the Orb's auction.|
 |`auctionMinimumDuration`|`uint256`| Minimum duration of the Orb's auction.|
 |`auctionBidExtension`|`uint256`|    Auction duration extension for late bids during the Orb auction.|
-|`holderTaxNumerator`|`uint256`|     Harberger tax numerator of the Orb, in basis points.|
+|`keeperTaxNumerator`|`uint256`|     Harberger tax numerator of the Orb, in basis points.|
 |`royaltyNumerator`|`uint256`|       Royalty numerator of the Orb, in basis points.|
 |`cooldown`|`uint256`|               Cooldown of the Orb in seconds.|
 |`cleartextMaximumLength`|`uint256`| Invocation cleartext maximum length for the Orb.|

--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -23,7 +23,7 @@ abstract contract DeployBase is Script {
     uint256 private immutable auctionMinimumDuration;
     uint256 private immutable auctionBidExtension;
 
-    uint256 private immutable holderTaxNumerator;
+    uint256 private immutable keeperTaxNumerator;
     uint256 private immutable royaltyNumerator;
 
     uint256 private immutable cooldown;
@@ -46,7 +46,7 @@ abstract contract DeployBase is Script {
         uint256 _auctionMinimumBidStep,
         uint256 _auctionMinimumDuration,
         uint256 _auctionBidExtension,
-        uint256 _holderTaxNumerator,
+        uint256 _keeperTaxNumerator,
         uint256 _royaltyNumerator,
         uint256 _cooldown,
         uint256 _cleartextMaximumLength
@@ -64,7 +64,7 @@ abstract contract DeployBase is Script {
         auctionMinimumDuration = _auctionMinimumDuration;
         auctionBidExtension = _auctionBidExtension;
 
-        holderTaxNumerator = _holderTaxNumerator;
+        keeperTaxNumerator = _keeperTaxNumerator;
         royaltyNumerator = _royaltyNumerator;
 
         cooldown = _cooldown;
@@ -99,7 +99,7 @@ abstract contract DeployBase is Script {
             auctionMinimumBidStep,
             auctionMinimumDuration,
             auctionBidExtension,
-            holderTaxNumerator,
+            keeperTaxNumerator,
             royaltyNumerator,
             cooldown,
             cleartextMaximumLength

--- a/script/DeployGoerli.s.sol
+++ b/script/DeployGoerli.s.sol
@@ -25,7 +25,7 @@ contract DeployGoerli is DeployBase {
     uint256 public immutable auctionMinimumDuration = 15 minutes;
     uint256 public immutable auctionBidExtension = 1 minutes;
 
-    uint256 public immutable holderTaxNumerator = 10_00;
+    uint256 public immutable keeperTaxNumerator = 10_00;
     uint256 public immutable royaltyNumerator = 10_00;
 
     uint256 public immutable cooldown = 5 minutes;
@@ -44,7 +44,7 @@ contract DeployGoerli is DeployBase {
             auctionMinimumBidStep,
             auctionMinimumDuration,
             auctionBidExtension,
-            holderTaxNumerator,
+            keeperTaxNumerator,
             royaltyNumerator,
             cooldown,
             cleartextMaximumLength

--- a/script/DeployLocal.s.sol
+++ b/script/DeployLocal.s.sol
@@ -22,7 +22,7 @@ contract DeployLocal is DeployBase {
     uint256 public immutable auctionMinimumDuration = 2 minutes;
     uint256 public immutable auctionBidExtension = 30 seconds;
 
-    uint256 public immutable holderTaxNumerator = 10_00;
+    uint256 public immutable keeperTaxNumerator = 10_00;
     uint256 public immutable royaltyNumerator = 10_00;
 
     uint256 public immutable cooldown = 2 minutes;
@@ -41,7 +41,7 @@ contract DeployLocal is DeployBase {
             auctionMinimumBidStep,
             auctionMinimumDuration,
             auctionBidExtension,
-            holderTaxNumerator,
+            keeperTaxNumerator,
             royaltyNumerator,
             cooldown,
             cleartextMaximumLength

--- a/script/DeployMainnnet.s.sol
+++ b/script/DeployMainnnet.s.sol
@@ -22,7 +22,7 @@ contract DeployMainnet is DeployBase {
     uint256 public immutable auctionMinimumDuration = 1 days;
     uint256 public immutable auctionBidExtension = 3 minutes;
 
-    uint256 public immutable holderTaxNumerator = 150_00;
+    uint256 public immutable keeperTaxNumerator = 150_00;
     uint256 public immutable royaltyNumerator = 10_00;
 
     uint256 public immutable cooldown = 7 days;
@@ -41,7 +41,7 @@ contract DeployMainnet is DeployBase {
             auctionMinimumBidStep,
             auctionMinimumDuration,
             auctionBidExtension,
-            holderTaxNumerator,
+            keeperTaxNumerator,
             royaltyNumerator,
             cooldown,
             cleartextMaximumLength

--- a/script/DeploySepolia.s.sol
+++ b/script/DeploySepolia.s.sol
@@ -22,7 +22,7 @@ contract DeploySepolia is DeployBase {
     uint256 public immutable auctionMinimumDuration = 15 minutes;
     uint256 public immutable auctionBidExtension = 1 minutes;
 
-    uint256 public immutable holderTaxNumerator = 10_00;
+    uint256 public immutable keeperTaxNumerator = 10_00;
     uint256 public immutable royaltyNumerator = 10_00;
 
     uint256 public immutable cooldown = 5 minutes;
@@ -41,7 +41,7 @@ contract DeploySepolia is DeployBase {
             auctionMinimumBidStep,
             auctionMinimumDuration,
             auctionBidExtension,
-            holderTaxNumerator,
+            keeperTaxNumerator,
             royaltyNumerator,
             cooldown,
             cleartextMaximumLength

--- a/src/IOrb.sol
+++ b/src/IOrb.sol
@@ -19,15 +19,15 @@ interface IOrb is IERC165 {
     // Funding Events
     event Deposit(address indexed depositor, uint256 indexed amount);
     event Withdrawal(address indexed recipient, uint256 indexed amount);
-    event Settlement(address indexed holder, address indexed beneficiary, uint256 indexed amount);
+    event Settlement(address indexed keeper, address indexed beneficiary, uint256 indexed amount);
 
     // Purchasing Errors
     event PriceUpdate(uint256 previousPrice, uint256 indexed newPrice);
     event Purchase(address indexed seller, address indexed buyer, uint256 indexed price);
 
     // Orb Ownership Functions
-    event Foreclosure(address indexed formerHolder);
-    event Relinquishment(address indexed formerHolder);
+    event Foreclosure(address indexed formerKeeper);
+    event Relinquishment(address indexed formerKeeper);
 
     // Invoking and Responding Events
     event Invocation(
@@ -53,8 +53,8 @@ interface IOrb is IERC165 {
         uint256 newBidExtension
     );
     event FeesUpdate(
-        uint256 previousHolderTaxNumerator,
-        uint256 indexed newHolderTaxNumerator,
+        uint256 previousKeeperTaxNumerator,
+        uint256 indexed newKeeperTaxNumerator,
         uint256 previousRoyaltyNumerator,
         uint256 indexed newRoyaltyNumerator
     );
@@ -71,8 +71,8 @@ interface IOrb is IERC165 {
     error TransferringNotSupported();
 
     // Authorization Errors
-    error AlreadyHolder();
-    error NotHolder();
+    error AlreadyKeeper();
+    error NotKeeper();
     error ContractHoldsOrb();
     error ContractDoesNotHoldOrb();
     error CreatorDoesNotControlOrb();
@@ -86,8 +86,8 @@ interface IOrb is IERC165 {
     error InsufficientBid(uint256 bidProvided, uint256 bidRequired);
 
     // Funding Errors
-    error HolderSolvent();
-    error HolderInsolvent();
+    error KeeperSolvent();
+    error KeeperInsolvent();
     error InsufficientFunds(uint256 fundsAvailable, uint256 fundsRequired);
 
     // Purchasing Errors
@@ -133,15 +133,15 @@ interface IOrb is IERC165 {
     // Funding View Functions
     function fundsOf(address owner) external view returns (uint256);
     function lastSettlementTime() external view returns (uint256);
-    function holderSolvent() external view returns (bool);
+    function keeperSolvent() external view returns (bool);
 
-    function holderTaxNumerator() external view returns (uint256);
+    function keeperTaxNumerator() external view returns (uint256);
     function feeDenominator() external view returns (uint256);
-    function holderTaxPeriod() external view returns (uint256);
+    function keeperTaxPeriod() external view returns (uint256);
 
     // Purchasing View Functions
     function price() external view returns (uint256);
-    function holderReceiveTime() external view returns (uint256);
+    function keeperReceiveTime() external view returns (uint256);
 
     function royaltyNumerator() external view returns (uint256);
 
@@ -187,7 +187,7 @@ interface IOrb is IERC165 {
     function purchase(
         uint256 newPrice,
         uint256 currentPrice,
-        uint256 currentHolderTaxNumerator,
+        uint256 currentKeeperTaxNumerator,
         uint256 currentRoyaltyNumerator,
         uint256 currentCooldown,
         uint256 currentCleartextMaximumLength
@@ -213,7 +213,7 @@ interface IOrb is IERC165 {
         uint256 newMinimumDuration,
         uint256 newBidExtension
     ) external;
-    function setFees(uint256 newHolderTaxNumerator, uint256 newRoyaltyNumerator) external;
+    function setFees(uint256 newKeeperTaxNumerator, uint256 newRoyaltyNumerator) external;
     function setCooldown(uint256 newCooldown) external;
     function setCleartextMaximumLength(uint256 newCleartextMaximumLength) external;
 }

--- a/src/OrbPond.sol
+++ b/src/OrbPond.sol
@@ -58,7 +58,7 @@ contract OrbPond is Ownable {
     /// @param   auctionMinimumBidStep   Minimum difference between bids in the Orb's auction.
     /// @param   auctionMinimumDuration  Minimum duration of the Orb's auction.
     /// @param   auctionBidExtension     Auction duration extension for late bids during the Orb auction.
-    /// @param   holderTaxNumerator      Harberger tax numerator of the Orb, in basis points.
+    /// @param   keeperTaxNumerator      Harberger tax numerator of the Orb, in basis points.
     /// @param   royaltyNumerator        Royalty numerator of the Orb, in basis points.
     /// @param   cooldown                Cooldown of the Orb in seconds.
     /// @param   cleartextMaximumLength  Invocation cleartext maximum length for the Orb.
@@ -68,7 +68,7 @@ contract OrbPond is Ownable {
         uint256 auctionMinimumBidStep,
         uint256 auctionMinimumDuration,
         uint256 auctionBidExtension,
-        uint256 holderTaxNumerator,
+        uint256 keeperTaxNumerator,
         uint256 royaltyNumerator,
         uint256 cooldown,
         uint256 cleartextMaximumLength
@@ -76,7 +76,7 @@ contract OrbPond is Ownable {
         orbs[orbId].setAuctionParameters(
             auctionStartingPrice, auctionMinimumBidStep, auctionMinimumDuration, auctionBidExtension
         );
-        orbs[orbId].setFees(holderTaxNumerator, royaltyNumerator);
+        orbs[orbId].setFees(keeperTaxNumerator, royaltyNumerator);
         orbs[orbId].setCooldown(cooldown);
         orbs[orbId].setCleartextMaximumLength(cleartextMaximumLength);
     }

--- a/test/OrbPond.t.sol
+++ b/test/OrbPond.t.sol
@@ -103,7 +103,7 @@ contract ConfigureTest is OrbPondTestBase {
             0.1 ether, // auctionMinimumBidStep
             1 days, // auctionMinimumDuration
             5 minutes, // auctionBidExtension
-            20_00, // holderTaxNumerator
+            20_00, // keeperTaxNumerator
             20_00, // royaltyNumerator
             3 days, // cooldownDuration
             100 // cooldownMaximumDuration
@@ -121,8 +121,8 @@ contract ConfigureTest is OrbPondTestBase {
         uint256 newBidExtension
     );
     event FeesUpdate(
-        uint256 previousHolderTaxNumerator,
-        uint256 indexed newHolderTaxNumerator,
+        uint256 previousKeeperTaxNumerator,
+        uint256 indexed newKeeperTaxNumerator,
         uint256 previousRoyaltyNumerator,
         uint256 indexed newRoyaltyNumerator
     );
@@ -139,7 +139,7 @@ contract ConfigureTest is OrbPondTestBase {
         assertEq(orb.auctionMinimumDuration(), 1 days);
         assertEq(orb.auctionBidExtension(), 5 minutes);
 
-        assertEq(orb.holderTaxNumerator(), 10_00);
+        assertEq(orb.keeperTaxNumerator(), 10_00);
         assertEq(orb.royaltyNumerator(), 10_00);
 
         assertEq(orb.cooldown(), 7 days);
@@ -160,8 +160,8 @@ contract ConfigureTest is OrbPondTestBase {
 
         vm.expectEmit(true, true, true, true);
         emit FeesUpdate(
-            10_00, // previousHolderTaxNumerator
-            20_00, // newHolderTaxNumerator
+            10_00, // previousKeeperTaxNumerator
+            20_00, // newKeeperTaxNumerator
             10_00, // previousRoyaltyNumerator
             20_00 // newRoyaltyNumerator
         );
@@ -179,7 +179,7 @@ contract ConfigureTest is OrbPondTestBase {
             0.2 ether, // auctionMinimumBidStep
             2 days, // auctionMinimumDuration
             10 minutes, // auctionBidExtension
-            20_00, // holderTaxNumerator
+            20_00, // keeperTaxNumerator
             20_00, // royaltyNumerator
             3 days, // cooldown
             100 // cleartextMaximumLength
@@ -190,7 +190,7 @@ contract ConfigureTest is OrbPondTestBase {
         assertEq(orb.auctionMinimumDuration(), 2 days);
         assertEq(orb.auctionBidExtension(), 10 minutes);
 
-        assertEq(orb.holderTaxNumerator(), 20_00);
+        assertEq(orb.keeperTaxNumerator(), 20_00);
         assertEq(orb.royaltyNumerator(), 20_00);
 
         assertEq(orb.cooldown(), 3 days);

--- a/test/harness/OrbHarness.sol
+++ b/test/harness/OrbHarness.sol
@@ -35,8 +35,8 @@ contract OrbHarness is
         lastSettlementTime = time;
     }
 
-    function workaround_setOrbHolder(address holder) public {
-        _transferOrb(ownerOf(tokenId), holder);
+    function workaround_setOrbKeeper(address keeper) public {
+        _transferOrb(ownerOf(tokenId), keeper);
     }
 
     function workaround_owedSinceLastSettlement() public view returns (uint256) {


### PR DESCRIPTION
Renaming Holder to Keeper in contracts, tests and scripts.