### PR TITLE
Adding response period as part of the Orb Oath

### DIFF
--- a/docs/src/src/IOrb.sol/interface.IOrb.md
+++ b/docs/src/src/IOrb.sol/interface.IOrb.md
@@ -1,5 +1,5 @@
 # IOrb
-[Git Source](https://github.com/orbland/orb/blob/b920ffa5c5298491a4db27902136f8424c03170e/src/IOrb.sol)
+[Git Source](https://github.com/orbland/orb/blob/8e1a9d33d24551d76e2256ec589cabf97e8c78aa/src/IOrb.sol)
 
 **Inherits:**
 IERC165

--- a/docs/src/src/IOrb.sol/interface.IOrb.md
+++ b/docs/src/src/IOrb.sol/interface.IOrb.md
@@ -1,5 +1,5 @@
 # IOrb
-[Git Source](https://github.com/orbland/orb/blob/ede71e56991e5a4a14f114e02bbcc807493c9804/src/IOrb.sol)
+[Git Source](https://github.com/orbland/orb/blob/b920ffa5c5298491a4db27902136f8424c03170e/src/IOrb.sol)
 
 **Inherits:**
 IERC165
@@ -205,6 +205,13 @@ function cleartextMaximumLength() external view returns (uint256);
 function honoredUntil() external view returns (uint256);
 ```
 
+### responsePeriod
+
+
+```solidity
+function responsePeriod() external view returns (uint256);
+```
+
 ### beneficiary
 
 
@@ -342,7 +349,7 @@ function flagResponse(uint256 invocationId) external;
 
 
 ```solidity
-function swearOath(bytes32 oathHash, uint256 newHonoredUntil) external;
+function swearOath(bytes32 oathHash, uint256 newHonoredUntil, uint256 newResponsePeriod) external;
 ```
 
 ### extendHonoredUntil
@@ -396,7 +403,7 @@ function setCleartextMaximumLength(uint256 newCleartextMaximumLength) external;
 ### Creation
 
 ```solidity
-event Creation(bytes32 indexed oathHash, uint256 indexed honoredUntil);
+event Creation();
 ```
 
 ### AuctionStart
@@ -492,7 +499,7 @@ event ResponseFlagging(uint256 indexed invocationId, address indexed flagger);
 ### OathSwearing
 
 ```solidity
-event OathSwearing(bytes32 indexed oathHash, uint256 indexed honoredUntil);
+event OathSwearing(bytes32 indexed oathHash, uint256 indexed honoredUntil, uint256 indexed responsePeriod);
 ```
 
 ### HonoredUntilUpdate

--- a/docs/src/src/Orb.sol/contract.Orb.md
+++ b/docs/src/src/Orb.sol/contract.Orb.md
@@ -1,5 +1,5 @@
 # Orb
-[Git Source](https://github.com/orbland/orb/blob/b920ffa5c5298491a4db27902136f8424c03170e/src/Orb.sol)
+[Git Source](https://github.com/orbland/orb/blob/8e1a9d33d24551d76e2256ec589cabf97e8c78aa/src/Orb.sol)
 
 **Inherits:**
 Ownable, ERC165, ERC721, [IOrb](/src/IOrb.sol/interface.IOrb.md)
@@ -487,9 +487,9 @@ function swearOath(bytes32 oathHash, uint256 newHonoredUntil, uint256 newRespons
 
 |Name|Type|Description|
 |----|----|-----------|
-|`oathHash`|`bytes32`|        Hash of the Oath taken to create the Orb.|
-|`newHonoredUntil`|`uint256`| Date until which the Orb creator will honor the Oath for the Orb keeper.|
-|`newResponsePeriod`|`uint256`||
+|`oathHash`|`bytes32`|          Hash of the Oath taken to create the Orb.|
+|`newHonoredUntil`|`uint256`|   Date until which the Orb creator will honor the Oath for the Orb keeper.|
+|`newResponsePeriod`|`uint256`| Duration within which the Orb creator promises to respond to an invocation.|
 
 
 ### extendHonoredUntil

--- a/docs/src/src/Orb.sol/contract.Orb.md
+++ b/docs/src/src/Orb.sol/contract.Orb.md
@@ -1,5 +1,5 @@
 # Orb
-[Git Source](https://github.com/orbland/orb/blob/ede71e56991e5a4a14f114e02bbcc807493c9804/src/Orb.sol)
+[Git Source](https://github.com/orbland/orb/blob/b920ffa5c5298491a4db27902136f8424c03170e/src/Orb.sol)
 
 **Inherits:**
 Ownable, ERC165, ERC721, [IOrb](/src/IOrb.sol/interface.IOrb.md)
@@ -88,6 +88,16 @@ Honored Until: timestamp until which the Orb Oath is honored for the keeper.
 
 ```solidity
 uint256 public honoredUntil;
+```
+
+
+### responsePeriod
+Response Period: time period in which the keeper promises to respond to an invocation.
+There are no penalties for being late within this contract.
+
+
+```solidity
+uint256 public responsePeriod;
 ```
 
 
@@ -308,15 +318,8 @@ This token represents the Orb and is called the Orb elsewhere in the contract.
 
 
 ```solidity
-constructor(
-    string memory name_,
-    string memory symbol_,
-    uint256 tokenId_,
-    address beneficiary_,
-    bytes32 oathHash_,
-    uint256 honoredUntil_,
-    string memory baseURI_
-) ERC721(name_, symbol_);
+constructor(string memory name_, string memory symbol_, uint256 tokenId_, address beneficiary_, string memory baseURI_)
+    ERC721(name_, symbol_);
 ```
 **Parameters**
 
@@ -326,8 +329,6 @@ constructor(
 |`symbol_`|`string`|       Orb symbol or ticker, used in ERC-721 metadata.|
 |`tokenId_`|`uint256`|      ERC-721 token id of the Orb.|
 |`beneficiary_`|`address`|  Address to receive all Orb proceeds.|
-|`oathHash_`|`bytes32`|     Hash of the Oath taken to create the Orb.|
-|`honoredUntil_`|`uint256`| Date until which the Orb creator will honor the Oath for the Orb keeper.|
 |`baseURI_`|`string`|      Initial baseURI value for tokenURI JSONs.|
 
 
@@ -477,7 +478,10 @@ decreased, unlike with the `extendHonoredUntil()` function.
 
 
 ```solidity
-function swearOath(bytes32 oathHash, uint256 newHonoredUntil) external onlyOwner onlyCreatorControlled;
+function swearOath(bytes32 oathHash, uint256 newHonoredUntil, uint256 newResponsePeriod)
+    external
+    onlyOwner
+    onlyCreatorControlled;
 ```
 **Parameters**
 
@@ -485,6 +489,7 @@ function swearOath(bytes32 oathHash, uint256 newHonoredUntil) external onlyOwner
 |----|----|-----------|
 |`oathHash`|`bytes32`|        Hash of the Oath taken to create the Orb.|
 |`newHonoredUntil`|`uint256`| Date until which the Orb creator will honor the Oath for the Orb keeper.|
+|`newResponsePeriod`|`uint256`||
 
 
 ### extendHonoredUntil

--- a/docs/src/src/OrbPond.sol/contract.OrbPond.md
+++ b/docs/src/src/OrbPond.sol/contract.OrbPond.md
@@ -1,5 +1,5 @@
 # OrbPond
-[Git Source](https://github.com/orbland/orb/blob/b920ffa5c5298491a4db27902136f8424c03170e/src/OrbPond.sol)
+[Git Source](https://github.com/orbland/orb/blob/8e1a9d33d24551d76e2256ec589cabf97e8c78aa/src/OrbPond.sol)
 
 **Inherits:**
 Ownable

--- a/docs/src/src/OrbPond.sol/contract.OrbPond.md
+++ b/docs/src/src/OrbPond.sol/contract.OrbPond.md
@@ -1,5 +1,5 @@
 # OrbPond
-[Git Source](https://github.com/orbland/orb/blob/ede71e56991e5a4a14f114e02bbcc807493c9804/src/OrbPond.sol)
+[Git Source](https://github.com/orbland/orb/blob/b920ffa5c5298491a4db27902136f8424c03170e/src/OrbPond.sol)
 
 **Inherits:**
 Ownable
@@ -45,8 +45,6 @@ function createOrb(
     string memory symbol,
     uint256 tokenId,
     address beneficiary,
-    bytes32 oathHash,
-    uint256 honoredUntil,
     string memory baseURI
 ) external onlyOwner;
 ```
@@ -58,8 +56,6 @@ function createOrb(
 |`symbol`|`string`|       Symbol of the Orb, used for display purposes. Suggestion: "ORB".|
 |`tokenId`|`uint256`|      TokenId of the Orb. Only one ERC-721 token will be minted, with this id.|
 |`beneficiary`|`address`|  Address of the Orb's beneficiary. See `Orb` contract for more on beneficiary.|
-|`oathHash`|`bytes32`|     Keccak-256 hash of the Orb's Oath.|
-|`honoredUntil`|`uint256`| Timestamp until which the Orb will be honored by its creator.|
 |`baseURI`|`string`|      Initial baseURI of the Orb, used as part of ERC-721 tokenURI.|
 
 
@@ -117,6 +113,6 @@ function transferOrbOwnership(uint256 orbId, address creatorAddress) external on
 ### OrbCreation
 
 ```solidity
-event OrbCreation(uint256 indexed orbId, address indexed orbAddress, bytes32 indexed oathHash, uint256 honoredUntil);
+event OrbCreation(uint256 indexed orbId, address indexed orbAddress);
 ```
 

--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -87,8 +87,6 @@ abstract contract DeployBase is Script {
             orbSymbol,
             tokenId, // tokenId
             splitterAddress, // beneficiary
-            0x0000000000000000000000000000000000000000000000000000000000000000, // oathHash
-            0, // honoredUntil
             "https://static.orb.land/orb/" // baseURI
         );
         orb = Orb(orbPond.orbs(0));

--- a/script/DeployGoerli.s.sol
+++ b/script/DeployGoerli.s.sol
@@ -17,9 +17,6 @@ contract DeployGoerli is DeployBase {
     string public orbSymbol = "ORB";
     uint256 public immutable tokenId = 1;
 
-    string public oath = "My orb is my promise, and my promise is my orb.";
-    uint256 public immutable honoredUntil = 1_700_000_000;
-
     uint256 public immutable auctionStartingPrice = 0.1 ether;
     uint256 public immutable auctionMinimumBidStep = 0.1 ether;
     uint256 public immutable auctionMinimumDuration = 15 minutes;

--- a/script/OrbScenario.s.sol
+++ b/script/OrbScenario.s.sol
@@ -14,6 +14,7 @@ contract OrbScenario is Script {
 
     string public oath = "My orb is my promise, and my promise is my orb.";
     uint256 public immutable honoredUntil = 1_700_000_000;
+    uint256 public immutable responsePeriod = 7 * 24 * 60 * 60;
 
     constructor() {
         creatorAddress = vm.envAddress("CREATOR_ADDRESS");
@@ -32,7 +33,7 @@ contract OrbScenario is Script {
 
         vm.startBroadcast(creatorKey);
 
-        orb.swearOath(keccak256(abi.encodePacked(oath)), honoredUntil);
+        orb.swearOath(keccak256(abi.encodePacked(oath)), honoredUntil, responsePeriod);
 
         vm.stopBroadcast();
     }

--- a/src/IOrb.sol
+++ b/src/IOrb.sol
@@ -8,7 +8,7 @@ interface IOrb is IERC165 {
     //  EVENTS
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    event Creation(bytes32 indexed oathHash, uint256 indexed honoredUntil);
+    event Creation();
 
     // Auction Events
     event AuctionStart(uint256 indexed auctionStartTime, uint256 indexed auctionEndTime);

--- a/src/IOrb.sol
+++ b/src/IOrb.sol
@@ -40,7 +40,7 @@ interface IOrb is IERC165 {
     event ResponseFlagging(uint256 indexed invocationId, address indexed flagger);
 
     // Orb Parameter Events
-    event OathSwearing(bytes32 indexed oathHash, uint256 indexed honoredUntil);
+    event OathSwearing(bytes32 indexed oathHash, uint256 indexed honoredUntil, uint256 indexed responsePeriod);
     event HonoredUntilUpdate(uint256 previousHonoredUntil, uint256 indexed newHonoredUntil);
     event AuctionParametersUpdate(
         uint256 previousStartingPrice,
@@ -163,6 +163,7 @@ interface IOrb is IERC165 {
 
     // Orb Parameter View Functions
     function honoredUntil() external view returns (uint256);
+    function responsePeriod() external view returns (uint256);
     function beneficiary() external view returns (address);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -204,7 +205,7 @@ interface IOrb is IERC165 {
     function flagResponse(uint256 invocationId) external;
 
     // Orb Parameter Functions
-    function swearOath(bytes32 oathHash, uint256 newHonoredUntil) external;
+    function swearOath(bytes32 oathHash, uint256 newHonoredUntil, uint256 newResponsePeriod) external;
     function extendHonoredUntil(uint256 newHonoredUntil) external;
     function setBaseURI(string memory newBaseURI) external;
     function setAuctionParameters(

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -184,24 +184,19 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
     /// @param  symbol_        Orb symbol or ticker, used in ERC-721 metadata.
     /// @param  tokenId_       ERC-721 token id of the Orb.
     /// @param  beneficiary_   Address to receive all Orb proceeds.
-    /// @param  oathHash_      Hash of the Oath taken to create the Orb.
-    /// @param  honoredUntil_  Date until which the Orb creator will honor the Oath for the Orb keeper.
     /// @param  baseURI_       Initial baseURI value for tokenURI JSONs.
     constructor(
         string memory name_,
         string memory symbol_,
         uint256 tokenId_,
         address beneficiary_,
-        bytes32 oathHash_,
-        uint256 honoredUntil_,
         string memory baseURI_
     ) ERC721(name_, symbol_) {
         tokenId = tokenId_;
         beneficiary = beneficiary_;
-        honoredUntil = honoredUntil_;
         baseURI = baseURI_;
 
-        emit Creation(oathHash_, honoredUntil_);
+        emit Creation();
 
         _safeMint(address(this), tokenId);
     }

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -321,8 +321,9 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
     ///          by the Orb creator when the Orb is in their control. With `swearOath()`, `honoredUntil` date can be
     ///          decreased, unlike with the `extendHonoredUntil()` function.
     /// @dev     Emits `OathSwearing`.
-    /// @param   oathHash         Hash of the Oath taken to create the Orb.
-    /// @param   newHonoredUntil  Date until which the Orb creator will honor the Oath for the Orb keeper.
+    /// @param   oathHash           Hash of the Oath taken to create the Orb.
+    /// @param   newHonoredUntil    Date until which the Orb creator will honor the Oath for the Orb keeper.
+    /// @param   newResponsePeriod  Duration within which the Orb creator promises to respond to an invocation.
     function swearOath(bytes32 oathHash, uint256 newHonoredUntil, uint256 newResponsePeriod)
         external
         onlyOwner

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -90,6 +90,9 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
 
     /// Honored Until: timestamp until which the Orb Oath is honored for the keeper.
     uint256 public honoredUntil;
+    /// Response Period: time period in which the keeper promises to respond to an invocation.
+    /// There are no penalties for being late within this contract.
+    uint256 public responsePeriod;
 
     /// Base URI for tokenURI JSONs. Initially set in the `constructor` and setable with `setBaseURI()`.
     string internal baseURI;
@@ -320,9 +323,14 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
     /// @dev     Emits `OathSwearing`.
     /// @param   oathHash         Hash of the Oath taken to create the Orb.
     /// @param   newHonoredUntil  Date until which the Orb creator will honor the Oath for the Orb keeper.
-    function swearOath(bytes32 oathHash, uint256 newHonoredUntil) external onlyOwner onlyCreatorControlled {
+    function swearOath(bytes32 oathHash, uint256 newHonoredUntil, uint256 newResponsePeriod)
+        external
+        onlyOwner
+        onlyCreatorControlled
+    {
         honoredUntil = newHonoredUntil;
-        emit OathSwearing(oathHash, newHonoredUntil);
+        responsePeriod = newResponsePeriod;
+        emit OathSwearing(oathHash, newHonoredUntil, newResponsePeriod);
     }
 
     /// @notice  Allows the Orb creator to extend the `honoredUntil` date. This function can be called by the Orb

--- a/src/OrbPond.sol
+++ b/src/OrbPond.sol
@@ -11,9 +11,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 ///          creator.
 /// @dev     Uses `Ownable`'s `owner()` to limit the creation of new Orbs to the administrator.
 contract OrbPond is Ownable {
-    event OrbCreation(
-        uint256 indexed orbId, address indexed orbAddress, bytes32 indexed oathHash, uint256 honoredUntil
-    );
+    event OrbCreation(uint256 indexed orbId, address indexed orbAddress);
 
     /// The mapping of Orb ids to Orbs. Increases monotonically.
     mapping(uint256 => Orb) public orbs;
@@ -25,16 +23,12 @@ contract OrbPond is Ownable {
     /// @param   symbol        Symbol of the Orb, used for display purposes. Suggestion: "ORB".
     /// @param   tokenId       TokenId of the Orb. Only one ERC-721 token will be minted, with this id.
     /// @param   beneficiary   Address of the Orb's beneficiary. See `Orb` contract for more on beneficiary.
-    /// @param   oathHash      Keccak-256 hash of the Orb's Oath.
-    /// @param   honoredUntil  Timestamp until which the Orb will be honored by its creator.
     /// @param   baseURI       Initial baseURI of the Orb, used as part of ERC-721 tokenURI.
     function createOrb(
         string memory name,
         string memory symbol,
         uint256 tokenId,
         address beneficiary,
-        bytes32 oathHash,
-        uint256 honoredUntil,
         string memory baseURI
     ) external onlyOwner {
         orbs[orbCount] = new Orb(
@@ -42,12 +36,10 @@ contract OrbPond is Ownable {
             symbol,
             tokenId,
             beneficiary,
-            oathHash,
-            honoredUntil,
             baseURI
         );
 
-        emit OrbCreation(orbCount, address(orbs[orbCount]), oathHash, honoredUntil);
+        emit OrbCreation(orbCount, address(orbs[orbCount]));
 
         orbCount++;
     }

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -18,12 +18,12 @@ contract OrbTestBase is Test {
 
     uint256 internal startingBalance;
 
-    event Creation(bytes32 indexed oathHash, uint256 indexed honoredUntil);
+    event Creation();
 
     function setUp() public {
         vm.expectEmit(true, true, true, true);
         // keccak hash of "test oath"
-        emit Creation(0xa0a79538f3c69ab225db00333ba71e9265d3835a715fd7e15ada45dc746608bc, 100);
+        emit Creation();
         orb = new OrbHarness();
         orb.setAuctionParameters(0.1 ether, 0.1 ether, 1 days, 5 minutes);
         user = address(0xBEEF);

--- a/test/OrbPond.t.sol
+++ b/test/OrbPond.t.sol
@@ -27,15 +27,7 @@ contract OrbPondTestBase is Test {
     }
 
     function deployDefaults() public returns (Orb orb) {
-        orbPond.createOrb(
-            "TestOrb",
-            "TEST",
-            100,
-            beneficiary,
-            0xa0a79538f3c69ab225db00333ba71e9265d3835a715fd7e15ada45dc746608bc,
-            100,
-            "test baseURI"
-        );
+        orbPond.createOrb("TestOrb", "TEST", 100, beneficiary, "test baseURI");
 
         return orbPond.orbs(0);
     }
@@ -52,44 +44,20 @@ contract DeployTest is OrbPondTestBase {
     function test_revertWhen_NotOwner() public {
         vm.prank(user);
         vm.expectRevert("Ownable: caller is not the owner");
-        orbPond.createOrb(
-            "TestOrb",
-            "TEST",
-            100,
-            beneficiary,
-            0xa0a79538f3c69ab225db00333ba71e9265d3835a715fd7e15ada45dc746608bc,
-            100,
-            "test baseURI"
-        );
+        orbPond.createOrb("TestOrb", "TEST", 100, beneficiary, "test baseURI");
     }
 
-    event Creation(bytes32 indexed oathHash, uint256 indexed honoredUntil);
-    event OrbCreation(
-        uint256 indexed orbId, address indexed orbAddress, bytes32 indexed oathHash, uint256 honoredUntil
-    );
+    event Creation();
+    event OrbCreation(uint256 indexed orbId, address indexed orbAddress);
 
     function test_deploy() public {
         vm.expectEmit(true, true, true, true);
-        // keccak hash of "test oath"
-        emit Creation(0xa0a79538f3c69ab225db00333ba71e9265d3835a715fd7e15ada45dc746608bc, 100);
+        emit Creation();
 
         vm.expectEmit(true, true, true, true);
-        emit OrbCreation(
-            0,
-            0x104fBc016F4bb334D775a19E8A6510109AC63E00,
-            0xa0a79538f3c69ab225db00333ba71e9265d3835a715fd7e15ada45dc746608bc,
-            100
-        );
+        emit OrbCreation(0, 0x104fBc016F4bb334D775a19E8A6510109AC63E00);
 
-        orbPond.createOrb(
-            "TestOrb",
-            "TEST",
-            100,
-            beneficiary,
-            0xa0a79538f3c69ab225db00333ba71e9265d3835a715fd7e15ada45dc746608bc,
-            100,
-            "test baseURI"
-        );
+        orbPond.createOrb("TestOrb", "TEST", 100, beneficiary, "test baseURI");
     }
 }
 

--- a/test/harness/OrbHarness.sol
+++ b/test/harness/OrbHarness.sol
@@ -10,8 +10,6 @@ contract OrbHarness is
         "ORB", // symbol
         69, // tokenId
         address(0xC0FFEE), // beneficiary
-        keccak256(abi.encodePacked("test oath")), // oathHash
-        100, // 1_700_000_000 // honoredUntil
         "https://static.orb.land/orb/" // baseURI
     )
 {


### PR DESCRIPTION
New public variable is part of observable commitment but does not introduce new logic.

This PR also removes Oath swearing from the constructor, as it doesn't fit all deployments.