### PR TITLE
Keeper auctions fixes

### DIFF
--- a/docs/src/src/IOrb.sol/interface.IOrb.md
+++ b/docs/src/src/IOrb.sol/interface.IOrb.md
@@ -1,5 +1,5 @@
 # IOrb
-[Git Source](https://github.com/orbland/orb/blob/133c7cb7df46e92042d00791655e7fc3990e50c3/src/IOrb.sol)
+[Git Source](https://github.com/orbland/orb/blob/cb187170016470708cbd1cff130aa6bcf6c25d76/src/IOrb.sol)
 
 **Inherits:**
 IERC165
@@ -328,14 +328,7 @@ function purchase(
 
 
 ```solidity
-function relinquish() external;
-```
-
-### relinquishWithAuction
-
-
-```solidity
-function relinquishWithAuction() external;
+function relinquish(bool withAuction) external;
 ```
 
 ### foreclose
@@ -617,6 +610,12 @@ error ContractDoesNotHoldOrb();
 
 ```solidity
 error CreatorDoesNotControlOrb();
+```
+
+### NotPermittedForCreator
+
+```solidity
+error NotPermittedForCreator();
 ```
 
 ### BeneficiaryDisallowed

--- a/docs/src/src/IOrb.sol/interface.IOrb.md
+++ b/docs/src/src/IOrb.sol/interface.IOrb.md
@@ -1,5 +1,5 @@
 # IOrb
-[Git Source](https://github.com/orbland/orb/blob/cb187170016470708cbd1cff130aa6bcf6c25d76/src/IOrb.sol)
+[Git Source](https://github.com/orbland/orb/blob/4884960208c025411fb80bb5ca6618bb05dd2627/src/IOrb.sol)
 
 **Inherits:**
 IERC165

--- a/docs/src/src/Orb.sol/contract.Orb.md
+++ b/docs/src/src/Orb.sol/contract.Orb.md
@@ -1,5 +1,5 @@
 # Orb
-[Git Source](https://github.com/orbland/orb/blob/cb187170016470708cbd1cff130aa6bcf6c25d76/src/Orb.sol)
+[Git Source](https://github.com/orbland/orb/blob/4884960208c025411fb80bb5ca6618bb05dd2627/src/Orb.sol)
 
 **Inherits:**
 Ownable, ERC165, ERC721, [IOrb](/src/IOrb.sol/interface.IOrb.md)
@@ -964,8 +964,7 @@ function purchase(
 
 *Assigns proceeds to beneficiary and primary receiver, accounting for royalty. Used by `purchase()` and
 `finalizeAuction()`. Fund deducation should happen before calling this function. Receiver might be
-beneficiary if no split is needed.
-MAXIMUM_PRICE to prevent potential overflows in math. Emits `PriceUpdate`.*
+beneficiary if no split is needed.*
 
 
 ```solidity

--- a/docs/src/src/OrbPond.sol/contract.OrbPond.md
+++ b/docs/src/src/OrbPond.sol/contract.OrbPond.md
@@ -1,5 +1,5 @@
 # OrbPond
-[Git Source](https://github.com/orbland/orb/blob/133c7cb7df46e92042d00791655e7fc3990e50c3/src/OrbPond.sol)
+[Git Source](https://github.com/orbland/orb/blob/cb187170016470708cbd1cff130aa6bcf6c25d76/src/OrbPond.sol)
 
 **Inherits:**
 Ownable

--- a/docs/src/src/OrbPond.sol/contract.OrbPond.md
+++ b/docs/src/src/OrbPond.sol/contract.OrbPond.md
@@ -1,5 +1,5 @@
 # OrbPond
-[Git Source](https://github.com/orbland/orb/blob/cb187170016470708cbd1cff130aa6bcf6c25d76/src/OrbPond.sol)
+[Git Source](https://github.com/orbland/orb/blob/4884960208c025411fb80bb5ca6618bb05dd2627/src/OrbPond.sol)
 
 **Inherits:**
 Ownable

--- a/src/IOrb.sol
+++ b/src/IOrb.sol
@@ -83,6 +83,7 @@ interface IOrb is IERC165 {
     error ContractHoldsOrb();
     error ContractDoesNotHoldOrb();
     error CreatorDoesNotControlOrb();
+    error NotPermittedForCreator();
     error BeneficiaryDisallowed();
 
     // Auction Errors
@@ -205,8 +206,7 @@ interface IOrb is IERC165 {
     ) external payable;
 
     // Orb Ownership Functions
-    function relinquish() external;
-    function relinquishWithAuction() external;
+    function relinquish(bool withAuction) external;
     function foreclose() external;
 
     // Invoking and Responding Functions

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -366,10 +366,12 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
     /// @notice  Allows the Orb creator to set the auction parameters. This function can only be called by the Orb
     ///          creator when the Orb is in their control.
     /// @dev     Emits `AuctionParametersUpdate`.
-    /// @param   newStartingPrice    New starting price for the auction. Can be 0.
-    /// @param   newMinimumBidStep   New minimum bid step for the auction. Will always be set to at least 1.
-    /// @param   newMinimumDuration  New minimum duration for the auction. Must be > 0.
-    /// @param   newBidExtension     New bid extension for the auction. Can be 0.
+    /// @param   newStartingPrice          New starting price for the auction. Can be 0.
+    /// @param   newMinimumBidStep         New minimum bid step for the auction. Will always be set to at least 1.
+    /// @param   newMinimumDuration        New minimum duration for the auction. Must be > 0.
+    /// @param   newKeeperMinimumDuration  New minimum duration for the auction is started by the keeper via
+    ///                                    `relinquishWithAuction()`. Must be > 0.
+    /// @param   newBidExtension           New bid extension for the auction. Can be 0.
     function setAuctionParameters(
         uint256 newStartingPrice,
         uint256 newMinimumBidStep,

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -835,7 +835,6 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
     /// @dev    Assigns proceeds to beneficiary and primary receiver, accounting for royalty. Used by `purchase()` and
     ///         `finalizeAuction()`. Fund deducation should happen before calling this function. Receiver might be
     ///         beneficiary if no split is needed.
-    ///         MAXIMUM_PRICE to prevent potential overflows in math. Emits `PriceUpdate`.
     /// @param  proceeds_  Total proceeds to split between beneficiary and receiver.
     /// @param  receiver_  Address of the receiver of the proceeds minus royalty.
     function _splitProceeds(uint256 proceeds_, address receiver_) internal {

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -508,7 +508,7 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
         }
 
         auctionEndTime = block.timestamp + auctionMinimumDuration;
-        auctionBeneficiary = address(0);
+        auctionBeneficiary = beneficiary;
 
         emit AuctionStart(block.timestamp, auctionEndTime);
     }

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -142,7 +142,7 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
     /// Leading bid: highest current bid. 0 not during the auction and before first bid.
     uint256 public leadingBid;
     /// Auction Beneficiary: address that receives most of the auction proceeds. Zero address if run by creator.
-    address public auctionBeneficiary = address(0);
+    address public auctionBeneficiary;
 
     // Invocation and Response State Variables
 


### PR DESCRIPTION
- relinquish() and relinquishWithAuction() combined into relinquish(withAuction).
- Orb creator may not call relinquish(true) - only other keepers may auction off the Orb that way
- Royalty calculations refactored to a separate function