### PR TITLE
Keeper auctions after foreclosure and minimum auction royalties

### DIFF
--- a/docs/src/src/IOrb.sol/interface.IOrb.md
+++ b/docs/src/src/IOrb.sol/interface.IOrb.md
@@ -1,5 +1,5 @@
 # IOrb
-[Git Source](https://github.com/orbland/orb/blob/4884960208c025411fb80bb5ca6618bb05dd2627/src/IOrb.sol)
+[Git Source](https://github.com/orbland/orb/blob/d276c4f3e5d63b502bfa11f2f239d0e4d5af694a/src/IOrb.sol)
 
 **Inherits:**
 IERC165

--- a/docs/src/src/Orb.sol/contract.Orb.md
+++ b/docs/src/src/Orb.sol/contract.Orb.md
@@ -1,5 +1,5 @@
 # Orb
-[Git Source](https://github.com/orbland/orb/blob/4884960208c025411fb80bb5ca6618bb05dd2627/src/Orb.sol)
+[Git Source](https://github.com/orbland/orb/blob/d276c4f3e5d63b502bfa11f2f239d0e4d5af694a/src/Orb.sol)
 
 **Inherits:**
 Ownable, ERC165, ERC721, [IOrb](/src/IOrb.sol/interface.IOrb.md)
@@ -579,7 +579,7 @@ function setAuctionParameters(
 |`newStartingPrice`|`uint256`|         New starting price for the auction. Can be 0.|
 |`newMinimumBidStep`|`uint256`|        New minimum bid step for the auction. Will always be set to at least 1.|
 |`newMinimumDuration`|`uint256`|       New minimum duration for the auction. Must be > 0.|
-|`newKeeperMinimumDuration`|`uint256`| New minimum duration for the auction is started by the keeper via `relinquishWithAuction()`. Must be > 0.|
+|`newKeeperMinimumDuration`|`uint256`| New minimum duration for the auction is started by the keeper via `relinquishWithAuction()`. Setting to 0 effectively disables keeper auctions.|
 |`newBidExtension`|`uint256`|          New bid extension for the auction. Can be 0.|
 
 
@@ -968,7 +968,7 @@ beneficiary if no split is needed.*
 
 
 ```solidity
-function _splitProceeds(uint256 proceeds_, address receiver_) internal;
+function _splitProceeds(uint256 proceeds_, address receiver_, uint256 royalty_) internal;
 ```
 **Parameters**
 
@@ -976,6 +976,7 @@ function _splitProceeds(uint256 proceeds_, address receiver_) internal;
 |----|----|-----------|
 |`proceeds_`|`uint256`| Total proceeds to split between beneficiary and receiver.|
 |`receiver_`|`address`| Address of the receiver of the proceeds minus royalty.|
+|`royalty_`|`uint256`|  Beneficiary royalty numerator to use for the split.|
 
 
 ### _setPrice

--- a/docs/src/src/OrbPond.sol/contract.OrbPond.md
+++ b/docs/src/src/OrbPond.sol/contract.OrbPond.md
@@ -1,5 +1,5 @@
 # OrbPond
-[Git Source](https://github.com/orbland/orb/blob/4884960208c025411fb80bb5ca6618bb05dd2627/src/OrbPond.sol)
+[Git Source](https://github.com/orbland/orb/blob/d276c4f3e5d63b502bfa11f2f239d0e4d5af694a/src/OrbPond.sol)
 
 **Inherits:**
 Ownable

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -909,6 +909,10 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
 
         emit Foreclosure(keeper);
 
+        auctionBeneficiary = keeper;
+        auctionEndTime = block.timestamp + auctionKeeperMinimumDuration;
+        emit AuctionStart(block.timestamp, auctionEndTime);
+
         _transferOrb(keeper, address(this));
     }
 

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -839,6 +839,7 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
     ///         beneficiary if no split is needed.
     /// @param  proceeds_  Total proceeds to split between beneficiary and receiver.
     /// @param  receiver_  Address of the receiver of the proceeds minus royalty.
+    /// @param  royalty_   Beneficiary royalty numerator to use for the split.
     function _splitProceeds(uint256 proceeds_, address receiver_, uint256 royalty_) internal {
         uint256 beneficiaryRoyalty = (proceeds_ * royalty_) / FEE_DENOMINATOR;
         uint256 receiverShare = proceeds_ - beneficiaryRoyalty;

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -370,7 +370,8 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
     /// @param   newMinimumBidStep         New minimum bid step for the auction. Will always be set to at least 1.
     /// @param   newMinimumDuration        New minimum duration for the auction. Must be > 0.
     /// @param   newKeeperMinimumDuration  New minimum duration for the auction is started by the keeper via
-    ///                                    `relinquishWithAuction()`. Must be > 0.
+    ///                                    `relinquishWithAuction()`. Setting to 0 effectively disables keeper
+    ///                                    auctions.
     /// @param   newBidExtension           New bid extension for the auction. Can be 0.
     function setAuctionParameters(
         uint256 newStartingPrice,
@@ -381,9 +382,6 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
     ) external onlyOwner onlyCreatorControlled {
         if (newMinimumDuration == 0) {
             revert InvalidAuctionDuration(newMinimumDuration);
-        }
-        if (newKeeperMinimumDuration == 0) {
-            revert InvalidAuctionDuration(newKeeperMinimumDuration);
         }
 
         uint256 previousStartingPrice = auctionStartingPrice;

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -879,7 +879,7 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
         price = 0;
         emit Relinquishment(msg.sender);
 
-        if (withAuction) {
+        if (withAuction && auctionKeeperMinimumDuration > 0) {
             if (owner() == msg.sender) {
                 revert NotPermittedForCreator();
             }
@@ -907,9 +907,11 @@ contract Orb is Ownable, ERC165, ERC721, IOrb {
 
         emit Foreclosure(keeper);
 
-        auctionBeneficiary = keeper;
-        auctionEndTime = block.timestamp + auctionKeeperMinimumDuration;
-        emit AuctionStart(block.timestamp, auctionEndTime);
+        if (auctionKeeperMinimumDuration > 0) {
+            auctionBeneficiary = keeper;
+            auctionEndTime = block.timestamp + auctionKeeperMinimumDuration;
+            emit AuctionStart(block.timestamp, auctionEndTime);
+        }
 
         _transferOrb(keeper, address(this));
     }

--- a/test/Orb.t.sol
+++ b/test/Orb.t.sol
@@ -276,9 +276,8 @@ contract SettingAuctionParametersTest is OrbTestBase {
         orb.setAuctionParameters(0.2 ether, 0.2 ether, 0, 1 days, 10 minutes);
     }
 
-    function test_revertIfKeeperAuctionDurationZero() public {
+    function test_allowKeeperAuctionDurationZero() public {
         vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(IOrb.InvalidAuctionDuration.selector, 0));
         orb.setAuctionParameters(0.2 ether, 0.2 ether, 2 days, 0, 10 minutes);
     }
 


### PR DESCRIPTION
- Allow setting auctionKeeperMinimumDuration to 0, disabling them
- If auctionKeeperMinimumDuration > 0, an auction is always started after foreclosure, for previous keeper's benefit
- To limit abuse of keeper auctions, minimum royalty is derived from from Harberger tax rate