### PR TITLE
Invocation Registry with invocation variants calling external contracts

### DIFF
--- a/src/IOrbInvocationRegistry.sol
+++ b/src/IOrbInvocationRegistry.sol
@@ -35,6 +35,7 @@ interface IOrbInvocationRegistry is IERC165Upgradeable {
     error NotCreator();
     error ContractHoldsOrb();
     error KeeperInsolvent();
+    error ContractNotAuthorized(address externalContract);
 
     // Invoking and Responding Errors
     error CooldownIncomplete(uint256 timeRemaining);
@@ -62,6 +63,8 @@ interface IOrbInvocationRegistry is IERC165Upgradeable {
     function responseFlagged(address orb, uint256 invocationId) external view returns (bool);
     function flaggedResponsesCount(address orb) external view returns (uint256);
 
+    function authorizedContracts(address contractAddress) external view returns (bool);
+
     function version() external view returns (uint256);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -69,7 +72,15 @@ interface IOrbInvocationRegistry is IERC165Upgradeable {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     function invokeWithCleartext(address orb, string memory cleartext) external;
+    function invokeWithCleartextAndCall(
+        address orb,
+        string memory cleartext,
+        address addressToCall,
+        bytes memory dataToCall
+    ) external;
     function invokeWithHash(address orb, bytes32 contentHash) external;
+    function invokeWithHashAndCall(address orb, bytes32 contentHash, address addressToCall, bytes memory dataToCall)
+        external;
     function respond(address orb, uint256 invocationId, bytes32 contentHash) external;
     function flagResponse(address orb, uint256 invocationId) external;
 }

--- a/test/ExternalCallee.sol
+++ b/test/ExternalCallee.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title   External Callee for Orb Invocation Registry test
+/// @author  Jonas Lekevicius
+/// @dev     Contract used to test `invokeWithXAndCall()` functions
+contract ExternalCallee {
+    error InvalidNumber(uint256 number);
+
+    event NumberUpdate(uint256 number);
+
+    uint256 public number = 42;
+
+    function setNumber(uint256 newNumber) public {
+        if (newNumber == 0) revert InvalidNumber(newNumber);
+        number = newNumber;
+        emit NumberUpdate(number);
+    }
+}

--- a/test/OrbInvocationRegistry.t.sol
+++ b/test/OrbInvocationRegistry.t.sol
@@ -135,7 +135,7 @@ contract SupportsInterfaceTest is OrbInvocationRegistryTestBase {
     function test_supportsInterface() public view {
         // console.logBytes4(type(IOrbInvocationRegistry).interfaceId);
         assert(orbInvocationRegistry.supportsInterface(0x01ffc9a7)); // ERC165 Interface ID for ERC165
-        assert(orbInvocationRegistry.supportsInterface(0x80089ce6)); // ERC165 Interface ID for IOrbInvocationRegistry
+        assert(orbInvocationRegistry.supportsInterface(0x767dfef3)); // ERC165 Interface ID for IOrbInvocationRegistry
     }
 }
 


### PR DESCRIPTION
Adds support for external contracts to respond to new invocations made. Contracts have to be manually authorized by OrbInvocationRegistry owner. Added to support tipping.