### PR TITLE
Remediating issues discovered during Oct 2023 Audit

### DIFF
--- a/src/CustomPaymentSplitter.sol
+++ b/src/CustomPaymentSplitter.sol
@@ -10,6 +10,7 @@ import {PaymentSplitterUpgradeable} from
 ///          implements an initializer, and has a constructor to disable the initializer on base deployment. Meant to be
 ///          used as an implementation to a EIP-1167 clone factory. This contract is not actually upgradeable despite
 ///          the name of the base contract.
+/// @custom:security-contact security@orb.land
 contract PaymentSplitter is PaymentSplitterUpgradeable {
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {

--- a/src/CustomUUPSUpgradeable.sol
+++ b/src/CustomUUPSUpgradeable.sol
@@ -15,6 +15,7 @@ import {ERC1967UpgradeUpgradeable} from
 ///          modified version of the OpenZeppelin Contract `UUPSUpgradeable` contract that does not expose any public
 ///          functions, to allow custom upgradeability logic to be implemented in the `Orb` contract.
 ///          Also, replaces string errors with custom errors.
+/// @custom:security-contact security@orb.land
 abstract contract UUPSUpgradeable is IERC1822ProxiableUpgradeable, ERC1967UpgradeUpgradeable {
     // Errors
     error RequiresCallViaDelegatecall();

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -66,6 +66,7 @@ import {OrbPond} from "./OrbPond.sol";
 ///          allow upgrades, if they are requested by the Creator and executed by the Keeper. The Orb is created as an
 ///          ERC-1967 proxy to an `Orb` implementation by the `OrbPond` contract, which is also used to track allowed
 ///          Orb upgrades and keeps a reference to an `OrbInvocationRegistry` used by this Orb.
+/// @custom:security-contact security@orb.land
 contract Orb is IERC721MetadataUpgradeable, ERC165Upgradeable, OwnableUpgradeable, UUPSUpgradeable {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //  EVENTS

--- a/src/OrbInvocationRegistry.sol
+++ b/src/OrbInvocationRegistry.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import {IERC165Upgradeable} from
-    "../lib/openzeppelin-contracts-upgradeable/contracts/utils/introspection/IERC165Upgradeable.sol";
 import {ERC165Upgradeable} from
     "../lib/openzeppelin-contracts-upgradeable/contracts/utils/introspection/ERC165Upgradeable.sol";
 import {OwnableUpgradeable} from "../lib/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";

--- a/src/OrbInvocationRegistry.sol
+++ b/src/OrbInvocationRegistry.sol
@@ -16,6 +16,7 @@ import {Orb} from "./Orb.sol";
 /// @notice  The Orb Invocation Registry is used to track invocations and responses for any Orb.
 /// @dev     `Orb`s using an `OrbInvocationRegistry` must implement `Orb` interface. Uses `Ownable`'s `owner()` to
 ///          guard upgrading.
+/// @custom:security-contact security@orb.land
 contract OrbInvocationRegistry is ERC165Upgradeable, OwnableUpgradeable, UUPSUpgradeable {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //  EVENTS

--- a/src/OrbInvocationTipJar.sol
+++ b/src/OrbInvocationTipJar.sol
@@ -13,6 +13,7 @@ import {OrbPond} from "./OrbPond.sol";
 /// @author  Jonas Lekevicius
 /// @author  Oren Yomtov
 /// @notice  This contract allows anyone to suggest an invocation to an Orb and optionally tip the Orb keeper.
+/// @custom:security-contact security@orb.land
 contract OrbInvocationTipJar is OwnableUpgradeable, UUPSUpgradeable {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //  STORAGE

--- a/src/OrbPond.sol
+++ b/src/OrbPond.sol
@@ -17,6 +17,7 @@ import {Orb} from "./Orb.sol";
 ///          implementations, and keeps a reference to an Orb Invocation Registry used by all Orbs created with this
 ///          Orb Pond.
 /// @dev     Uses `Ownable`'s `owner()` to limit the creation of new Orbs to the administrator and for upgrades.
+/// @custom:security-contact security@orb.land
 contract OrbPond is OwnableUpgradeable, UUPSUpgradeable {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //  EVENTS

--- a/src/OrbPond.sol
+++ b/src/OrbPond.sol
@@ -100,8 +100,7 @@ contract OrbPond is OwnableUpgradeable, UUPSUpgradeable {
         address beneficiary = ClonesUpgradeable.clone(paymentSplitterImplementation);
         PaymentSplitter(payable(beneficiary)).initialize(payees_, shares_);
 
-        bytes memory initializeCalldata =
-            abi.encodeWithSelector(Orb.initialize.selector, beneficiary, name, symbol, tokenURI);
+        bytes memory initializeCalldata = abi.encodeCall(Orb.initialize, (beneficiary, name, symbol, tokenURI));
         ERC1967Proxy proxy = new ERC1967Proxy(versions[1], initializeCalldata);
         orbs[orbCount] = address(proxy);
         IOwnershipTransferrable(orbs[orbCount]).transferOwnership(msg.sender);

--- a/src/OrbPondV2.sol
+++ b/src/OrbPondV2.sol
@@ -22,6 +22,7 @@ import {Orb} from "./Orb.sol";
 ///          - `beneficiaryWithdrawalAddresses` mapping to authorize addresses to be used as
 ///            `beneficiaryWithdrawalAddress` on Orbs, `authorizeWithdrawalAddress()` function to set it, and
 ///            `beneficiaryWithdrawalAddressPermitted()` function to check if address is authorized.
+/// @custom:security-contact security@orb.land
 contract OrbPondV2 is OrbPond {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //  EVENTS

--- a/src/OrbPondV2.sol
+++ b/src/OrbPondV2.sol
@@ -81,8 +81,7 @@ contract OrbPondV2 is OrbPond {
         address beneficiary = ClonesUpgradeable.clone(paymentSplitterImplementation);
         PaymentSplitter(payable(beneficiary)).initialize(payees_, shares_);
 
-        bytes memory initializeCalldata =
-            abi.encodeWithSelector(Orb.initialize.selector, beneficiary, name, symbol, tokenURI);
+        bytes memory initializeCalldata = abi.encodeCall(Orb.initialize, (beneficiary, name, symbol, tokenURI));
         ERC1967Proxy proxy = new ERC1967Proxy(versions[orbInitialVersion], initializeCalldata);
         orbs[orbCount] = address(proxy);
         IOwnershipTransferrable(orbs[orbCount]).transferOwnership(msg.sender);

--- a/src/OrbV2.sol
+++ b/src/OrbV2.sol
@@ -452,13 +452,7 @@ contract OrbV2 is Orb {
     ///          Does not allow settlement in the same block before `purchase()` to prevent transfers that avoid
     ///          royalty payments. Does not allow purchasing from yourself. Emits `PriceUpdate` and `Purchase`.
     ///          V2 changes to require providing Keeper auction royalty to prevent front-running.
-    /// @param   newPrice                        New price to use after the purchase.
-    /// @param   currentPrice                    Current price, to prevent front-running.
-    /// @param   currentKeeperTaxNumerator       Current keeper tax numerator, to prevent front-running.
-    /// @param   currentRoyaltyNumerator         Current royalty numerator, to prevent front-running.
-    /// @param   currentAuctionRoyaltyNumerator  Current keeper auction royalty numerator, to prevent front-running.
-    /// @param   currentCooldown                 Current cooldown, to prevent front-running.
-    /// @param   currentCleartextMaximumLength   Current cleartext maximum length, to prevent front-running.
+    /// @param   currentHonoredUntil              Current honored until timestamp, to prevent front-running.
     function purchase(
         uint256 newPrice,
         uint256 currentPrice,
@@ -466,7 +460,8 @@ contract OrbV2 is Orb {
         uint256 currentRoyaltyNumerator,
         uint256 currentAuctionRoyaltyNumerator,
         uint256 currentCooldown,
-        uint256 currentCleartextMaximumLength
+        uint256 currentCleartextMaximumLength,
+        uint256 currentHonoredUntil
     ) external payable virtual onlyKeeperHeld onlyKeeperSolvent {
         if (currentPrice != price) {
             revert CurrentValueIncorrect(currentPrice, price);
@@ -485,6 +480,9 @@ contract OrbV2 is Orb {
         }
         if (currentCleartextMaximumLength != cleartextMaximumLength) {
             revert CurrentValueIncorrect(currentCleartextMaximumLength, cleartextMaximumLength);
+        }
+        if (currentHonoredUntil != honoredUntil) {
+            revert CurrentValueIncorrect(currentHonoredUntil, honoredUntil);
         }
 
         if (lastSettlementTime >= block.timestamp) {

--- a/src/OrbV2.sol
+++ b/src/OrbV2.sol
@@ -70,6 +70,7 @@ import {OrbPondV2} from "./OrbPondV2.sol";
 ///          - Event changes: `OathSwearing` parameter change, `InvocationParametersUpdate` added (replaces
 ///            `CooldownUpdate` and `CleartextMaximumLengthUpdate`), `FeesUpdate` parameter change,
 ///            `BeneficiaryWithdrawalAddressUpdate` added.
+/// @custom:security-contact security@orb.land
 contract OrbV2 is Orb {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //  EVENTS

--- a/src/OrbV2.sol
+++ b/src/OrbV2.sol
@@ -138,7 +138,7 @@ contract OrbV2 is Orb {
         public
         virtual
         override
-        initializer
+        reinitializer(2)
     {
         __Ownable_init();
         __UUPSUpgradeable_init();

--- a/src/test-upgrades/OrbPondTestUpgrade.sol
+++ b/src/test-upgrades/OrbPondTestUpgrade.sol
@@ -50,8 +50,7 @@ contract OrbPondTestUpgrade is OrbPondV2 {
         address beneficiary = ClonesUpgradeable.clone(paymentSplitterImplementation);
         PaymentSplitter(payable(beneficiary)).initialize(beneficiaryAddresses, beneficiaryShares);
 
-        bytes memory initializeCalldata =
-            abi.encodeWithSelector(Orb.initialize.selector, beneficiary, name, symbol, tokenURI);
+        bytes memory initializeCalldata = abi.encodeCall(Orb.initialize, (beneficiary, name, symbol, tokenURI));
         ERC1967Proxy proxy = new ERC1967Proxy(versions[1], initializeCalldata);
         orbs[orbCount] = address(proxy);
         IOwnershipTransferrable(orbs[orbCount]).transferOwnership(msg.sender);

--- a/test/OrbV1/OrbV1-Auction.t.sol
+++ b/test/OrbV1/OrbV1-Auction.t.sol
@@ -330,7 +330,7 @@ contract FinalizeAuctionTest is OrbTestBase {
         assertEq(orb.fundsOf(user2), funds);
         assertEq(orb.fundsOf(address(orb)), 0);
 
-        uint256 beneficiaryRoyalty = (amount * orb.royaltyNumerator()) / orb.feeDenominator();
+        uint256 beneficiaryRoyalty = (amount * orb.purchaseRoyaltyNumerator()) / orb.feeDenominator();
         uint256 auctionBeneficiaryShare = amount - beneficiaryRoyalty;
         uint256 userFunds = orb.fundsOf(user);
         uint256 beneficiaryFunds = orb.fundsOf(beneficiary);
@@ -370,7 +370,7 @@ contract FinalizeAuctionTest is OrbTestBase {
         vm.warp(orb.auctionEndTime() + 1);
         uint256 minBeneficiaryNumerator =
             orb.keeperTaxNumerator() * orb.auctionKeeperMinimumDuration() / orb.keeperTaxPeriod();
-        assertTrue(minBeneficiaryNumerator > orb.royaltyNumerator());
+        assertTrue(minBeneficiaryNumerator > orb.purchaseRoyaltyNumerator());
         uint256 minBeneficiaryRoyalty = (amount * minBeneficiaryNumerator) / orb.feeDenominator();
         uint256 auctionBeneficiaryShare = amount - minBeneficiaryRoyalty;
         uint256 userFunds = orb.fundsOf(user);

--- a/test/OrbV1/OrbV1-Purchase.t.sol
+++ b/test/OrbV1/OrbV1-Purchase.t.sol
@@ -193,7 +193,7 @@ contract PurchaseTest is OrbTestBase {
     function test_succeedsCorrectly() public {
         uint256 bidAmount = 1 ether;
         uint256 newPrice = 3 ether;
-        uint256 expectedSettlement = bidAmount * orb.royaltyNumerator() / orb.feeDenominator();
+        uint256 expectedSettlement = bidAmount * orb.purchaseRoyaltyNumerator() / orb.feeDenominator();
         uint256 purchaseAmount = bidAmount / 2;
         uint256 depositAmount = bidAmount / 2;
         // bidAmount will be the `_price` of the Orb
@@ -223,7 +223,7 @@ contract PurchaseTest is OrbTestBase {
         // that the user transfers when calling `purchase()`
         vm.prank(user2);
         orb.purchase{value: purchaseAmount + 1}(newPrice, bidAmount, 10_00, 10_00, 7 days, 280);
-        uint256 beneficiaryRoyalty = ((bidAmount * orb.royaltyNumerator()) / orb.feeDenominator());
+        uint256 beneficiaryRoyalty = ((bidAmount * orb.purchaseRoyaltyNumerator()) / orb.feeDenominator());
         assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty + expectedSettlement);
         assertEq(orb.fundsOf(user), userBefore + (bidAmount - beneficiaryRoyalty - expectedSettlement));
         assertEq(orb.fundsOf(owner), ownerBefore);
@@ -238,7 +238,7 @@ contract PurchaseTest is OrbTestBase {
         newPrice = bound(newPrice, 1, orb.workaround_maximumPrice());
         buyPrice = bound(buyPrice, bidAmount + 1, orb.workaround_maximumPrice());
         diff = bound(diff, 1, buyPrice);
-        uint256 expectedSettlement = bidAmount * orb.royaltyNumerator() / orb.feeDenominator();
+        uint256 expectedSettlement = bidAmount * orb.purchaseRoyaltyNumerator() / orb.feeDenominator();
         vm.deal(user2, buyPrice);
         /// Break up the amount between depositing and purchasing to test more scenarios
         uint256 purchaseAmount = buyPrice - diff;
@@ -272,7 +272,7 @@ contract PurchaseTest is OrbTestBase {
         // We bound the purchaseAmount to be higher than the current price (bidAmount)
         vm.prank(user2);
         orb.purchase{value: purchaseAmount}(newPrice, bidAmount, 10_00, 10_00, 7 days, 280);
-        uint256 beneficiaryRoyalty = ((bidAmount * orb.royaltyNumerator()) / orb.feeDenominator());
+        uint256 beneficiaryRoyalty = ((bidAmount * orb.purchaseRoyaltyNumerator()) / orb.feeDenominator());
         assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty + expectedSettlement);
         assertEq(orb.fundsOf(user), userBefore + (bidAmount - beneficiaryRoyalty - expectedSettlement));
         assertEq(orb.fundsOf(owner), ownerBefore);

--- a/test/OrbV1/OrbV1-Settings.t.sol
+++ b/test/OrbV1/OrbV1-Settings.t.sol
@@ -211,18 +211,18 @@ contract SettingFeesTest is OrbTestBase {
         orb.setFees(largeNumerator, orb.feeDenominator());
 
         assertEq(orb.keeperTaxNumerator(), largeNumerator);
-        assertEq(orb.royaltyNumerator(), orb.feeDenominator());
+        assertEq(orb.purchaseRoyaltyNumerator(), orb.feeDenominator());
     }
 
     function test_setFeesSucceedsCorrectly() public {
         assertEq(orb.keeperTaxNumerator(), 10_00);
-        assertEq(orb.royaltyNumerator(), 10_00);
+        assertEq(orb.purchaseRoyaltyNumerator(), 10_00);
         vm.prank(owner);
         vm.expectEmit(true, true, true, true);
         emit FeesUpdate(10_00, 100_00, 10_00, 100_00);
         orb.setFees(100_00, 100_00);
         assertEq(orb.keeperTaxNumerator(), 100_00);
-        assertEq(orb.royaltyNumerator(), 100_00);
+        assertEq(orb.purchaseRoyaltyNumerator(), 100_00);
     }
 }
 

--- a/test/OrbV1/OrbV1.t.sol
+++ b/test/OrbV1/OrbV1.t.sol
@@ -162,7 +162,7 @@ contract InitialStateTest is OrbTestBase {
 
         assertEq(orb.price(), 0);
         assertEq(orb.keeperTaxNumerator(), 10_00);
-        assertEq(orb.royaltyNumerator(), 10_00);
+        assertEq(orb.purchaseRoyaltyNumerator(), 10_00);
         assertEq(orb.lastInvocationTime(), 0);
 
         assertEq(orb.auctionStartingPrice(), 0.1 ether);

--- a/test/OrbV2/OrbV2-Purchase.t.sol
+++ b/test/OrbV2/OrbV2-Purchase.t.sol
@@ -65,7 +65,7 @@ contract PurchaseTest is OrbTestBase {
     function test_revertsIfHeldByContract() public {
         vm.prank(user);
         vm.expectRevert(Orb.ContractHoldsOrb.selector);
-        orb.purchase(100, 0, 120_00, 10_00, 30_00, 7 days, 300);
+        orb.purchase(100, 0, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
     }
 
     function test_revertsIfKeeperInsolvent() public {
@@ -73,7 +73,7 @@ contract PurchaseTest is OrbTestBase {
         vm.warp(block.timestamp + 1300 days);
         vm.prank(user2);
         vm.expectRevert(Orb.KeeperInsolvent.selector);
-        orb.purchase(100, 1 ether, 120_00, 10_00, 30_00, 7 days, 300);
+        orb.purchase(100, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
     }
 
     function test_purchaseSettlesFirst() public {
@@ -81,7 +81,7 @@ contract PurchaseTest is OrbTestBase {
         // after making `user` the current keeper of the Orb, `makeKeeperAndWarp(user, )` warps 30 days into the future
         assertEq(orb.lastSettlementTime(), block.timestamp - 30 days);
         vm.prank(user2);
-        orb.purchase{value: 1.1 ether}(2 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300);
+        orb.purchase{value: 1.1 ether}(2 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
         assertEq(orb.lastSettlementTime(), block.timestamp);
     }
 
@@ -90,12 +90,12 @@ contract PurchaseTest is OrbTestBase {
         vm.deal(beneficiary, 1.1 ether);
         vm.prank(beneficiary);
         vm.expectRevert(abi.encodeWithSelector(Orb.NotPermitted.selector));
-        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
 
         // does not revert
         assertEq(orb.lastSettlementTime(), block.timestamp - 30 days);
         vm.prank(user2);
-        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
         assertEq(orb.lastSettlementTime(), block.timestamp);
     }
 
@@ -103,7 +103,7 @@ contract PurchaseTest is OrbTestBase {
         makeKeeperAndWarp(user, 1 ether);
         vm.prank(user2);
         vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 2 ether, 1 ether));
-        orb.purchase{value: 1.1 ether}(3 ether, 2 ether, 120_00, 10_00, 30_00, 7 days, 300);
+        orb.purchase{value: 1.1 ether}(3 ether, 2 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
     }
 
     function test_revertsIfWrongCurrentValues() public {
@@ -111,40 +111,44 @@ contract PurchaseTest is OrbTestBase {
 
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 200_00, 120_00));
-        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 200_00, 10_00, 30_00, 7 days, 300);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 200_00, 10_00, 30_00, 7 days, 300, 20_000_000);
 
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 30_00, 10_00));
-        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 30_00, 30_00, 7 days, 300);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 30_00, 30_00, 7 days, 300, 20_000_000);
 
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 10_00, 30_00));
-        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 10_00, 7 days, 300);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 10_00, 7 days, 300, 20_000_000);
 
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 8 days, 7 days));
-        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 8 days, 300);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 8 days, 300, 20_000_000);
 
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 150, 300));
-        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 150);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 150, 20_000_000);
 
         vm.prank(user);
-        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300);
+        vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 10_000_000, 20_000_000));
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 10_000_000);
+
+        vm.prank(user);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
     }
 
     function test_revertsIfIfAlreadyKeeper() public {
         makeKeeperAndWarp(user, 1 ether);
         vm.expectRevert(Orb.AlreadyKeeper.selector);
         vm.prank(user);
-        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
     }
 
     function test_revertsIfInsufficientFunds() public {
         makeKeeperAndWarp(user, 1 ether);
         vm.expectRevert(abi.encodeWithSelector(Orb.InsufficientFunds.selector, 1 ether - 1, 1 ether));
         vm.prank(user2);
-        orb.purchase{value: 1 ether - 1}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300);
+        orb.purchase{value: 1 ether - 1}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
     }
 
     function test_revertsIfPurchasingAfterSetPrice() public {
@@ -153,7 +157,7 @@ contract PurchaseTest is OrbTestBase {
         orb.setPrice(0);
         vm.expectRevert(abi.encodeWithSelector(Orb.PurchasingNotPermitted.selector));
         vm.prank(user2);
-        orb.purchase(1 ether, 0, 120_00, 10_00, 30_00, 7 days, 300);
+        orb.purchase(1 ether, 0, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
     }
 
     event Purchase(address indexed seller, address indexed buyer, uint256 indexed price);
@@ -183,7 +187,7 @@ contract PurchaseTest is OrbTestBase {
         // The Orb is purchased with purchaseAmount
         // It uses both the existing funds of the user and the funds
         // that the user transfers when calling `purchase()`
-        orb.purchase{value: purchaseAmount + 1}(newPrice, bidAmount, 120_00, 10_00, 30_00, 7 days, 300);
+        orb.purchase{value: purchaseAmount + 1}(newPrice, bidAmount, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
         uint256 beneficiaryRoyalty = bidAmount;
         assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty);
         assertEq(orb.fundsOf(owner), ownerBefore);
@@ -226,7 +230,7 @@ contract PurchaseTest is OrbTestBase {
         // It uses both the existing funds of the user and the funds
         // that the user transfers when calling `purchase()`
         vm.prank(user2);
-        orb.purchase{value: purchaseAmount + 1}(newPrice, bidAmount, 120_00, 10_00, 30_00, 7 days, 300);
+        orb.purchase{value: purchaseAmount + 1}(newPrice, bidAmount, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
         uint256 beneficiaryRoyalty = ((bidAmount * orb.royaltyNumerator()) / orb.feeDenominator());
         assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty + expectedSettlement);
         assertEq(orb.fundsOf(user), userBefore + bidAmount - (beneficiaryRoyalty + expectedSettlement));
@@ -275,7 +279,7 @@ contract PurchaseTest is OrbTestBase {
         // that the user transfers when calling `purchase()`
         // We bound the purchaseAmount to be higher than the current price (bidAmount)
         vm.prank(user2);
-        orb.purchase{value: purchaseAmount}(newPrice, bidAmount, 120_00, 10_00, 30_00, 7 days, 300);
+        orb.purchase{value: purchaseAmount}(newPrice, bidAmount, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
         uint256 beneficiaryRoyalty = ((bidAmount * orb.royaltyNumerator()) / orb.feeDenominator());
         assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty + expectedSettlement);
         assertEq(orb.fundsOf(user), userBefore + bidAmount - (beneficiaryRoyalty + expectedSettlement));

--- a/test/OrbV2/OrbV2-Purchase.t.sol
+++ b/test/OrbV2/OrbV2-Purchase.t.sol
@@ -231,7 +231,7 @@ contract PurchaseTest is OrbTestBase {
         // that the user transfers when calling `purchase()`
         vm.prank(user2);
         orb.purchase{value: purchaseAmount + 1}(newPrice, bidAmount, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
-        uint256 beneficiaryRoyalty = ((bidAmount * orb.royaltyNumerator()) / orb.feeDenominator());
+        uint256 beneficiaryRoyalty = ((bidAmount * orb.purchaseRoyaltyNumerator()) / orb.feeDenominator());
         assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty + expectedSettlement);
         assertEq(orb.fundsOf(user), userBefore + bidAmount - (beneficiaryRoyalty + expectedSettlement));
         assertEq(orb.fundsOf(owner), ownerBefore);
@@ -280,7 +280,7 @@ contract PurchaseTest is OrbTestBase {
         // We bound the purchaseAmount to be higher than the current price (bidAmount)
         vm.prank(user2);
         orb.purchase{value: purchaseAmount}(newPrice, bidAmount, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
-        uint256 beneficiaryRoyalty = ((bidAmount * orb.royaltyNumerator()) / orb.feeDenominator());
+        uint256 beneficiaryRoyalty = ((bidAmount * orb.purchaseRoyaltyNumerator()) / orb.feeDenominator());
         assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty + expectedSettlement);
         assertEq(orb.fundsOf(user), userBefore + bidAmount - (beneficiaryRoyalty + expectedSettlement));
         assertEq(orb.fundsOf(owner), ownerBefore);

--- a/test/OrbV2/OrbV2-Settings.t.sol
+++ b/test/OrbV2/OrbV2-Settings.t.sol
@@ -302,13 +302,13 @@ contract SettingFeesTest is OrbTestBase {
         orb.setFees(largeNumerator, orb.feeDenominator(), orb.feeDenominator());
 
         assertEq(orb.keeperTaxNumerator(), largeNumerator);
-        assertEq(orb.royaltyNumerator(), orb.feeDenominator());
+        assertEq(orb.purchaseRoyaltyNumerator(), orb.feeDenominator());
         assertEq(orb.auctionRoyaltyNumerator(), orb.feeDenominator());
     }
 
     function test_setFeesSucceedsCorrectly() public {
         assertEq(orb.keeperTaxNumerator(), 120_00);
-        assertEq(orb.royaltyNumerator(), 10_00);
+        assertEq(orb.purchaseRoyaltyNumerator(), 10_00);
         assertEq(orb.auctionRoyaltyNumerator(), 30_00);
 
         vm.prank(owner);
@@ -317,7 +317,7 @@ contract SettingFeesTest is OrbTestBase {
 
         orb.setFees(100_00, 100_00, 100_00);
         assertEq(orb.keeperTaxNumerator(), 100_00);
-        assertEq(orb.royaltyNumerator(), 100_00);
+        assertEq(orb.purchaseRoyaltyNumerator(), 100_00);
         assertEq(orb.auctionRoyaltyNumerator(), 100_00);
     }
 
@@ -337,7 +337,7 @@ contract SettingFeesTest is OrbTestBase {
         orb.setFees(200_00, 90_00, 90_00);
 
         assertTrue(orb.keeperTaxNumerator() != 200_00);
-        assertTrue(orb.royaltyNumerator() != 90_00);
+        assertTrue(orb.purchaseRoyaltyNumerator() != 90_00);
         assertTrue(orb.auctionRoyaltyNumerator() != 90_00);
 
         vm.warp(orb.honoredUntil() + 1);
@@ -351,7 +351,7 @@ contract SettingFeesTest is OrbTestBase {
         vm.prank(owner);
         orb.setFees(200_00, 90_00, 90_00);
         assertEq(orb.keeperTaxNumerator(), 200_00);
-        assertEq(orb.royaltyNumerator(), 90_00);
+        assertEq(orb.purchaseRoyaltyNumerator(), 90_00);
         assertEq(orb.auctionRoyaltyNumerator(), 90_00);
     }
 
@@ -360,14 +360,14 @@ contract SettingFeesTest is OrbTestBase {
         orb.listWithPrice(1 ether);
 
         assertTrue(orb.keeperTaxNumerator() != 200_00);
-        assertTrue(orb.royaltyNumerator() != 90_00);
+        assertTrue(orb.purchaseRoyaltyNumerator() != 90_00);
         assertTrue(orb.auctionRoyaltyNumerator() != 90_00);
         assertGt(orb.honoredUntil(), block.timestamp);
 
         vm.prank(owner);
         orb.setFees(200_00, 90_00, 90_00);
         assertEq(orb.keeperTaxNumerator(), 200_00);
-        assertEq(orb.royaltyNumerator(), 90_00);
+        assertEq(orb.purchaseRoyaltyNumerator(), 90_00);
         assertEq(orb.auctionRoyaltyNumerator(), 90_00);
     }
 

--- a/test/OrbV2/OrbV2-Upgrade.t.sol
+++ b/test/OrbV2/OrbV2-Upgrade.t.sol
@@ -267,7 +267,7 @@ contract UpgradeFromV1Test is OrbTestBase {
 
         assertEq(testOrb.version(), 1);
         assertEq(testOrb.responsePeriod(), 0);
-        assertEq(testOrb.royaltyNumerator(), 10_00);
+        assertEq(testOrb.purchaseRoyaltyNumerator(), 10_00);
         bytes4 auctionRoyaltyNumeratorSelector = bytes4(keccak256("auctionRoyaltyNumerator()"));
         // solhint-disable-next-line avoid-low-level-calls
         (bool successBefore,) = address(testOrb).call(abi.encodeWithSelector(auctionRoyaltyNumeratorSelector));

--- a/test/OrbV2/OrbV2.t.sol
+++ b/test/OrbV2/OrbV2.t.sol
@@ -212,6 +212,11 @@ contract InitialStateTest is OrbTestBase {
         orb.initialize(address(0), "", "", "");
     }
 
+    function test_revertsV2Initializer() public {
+        vm.expectRevert("Initializable: contract is already initialized");
+        orb.initializeV2();
+    }
+
     function test_initializerSuccess() public {
         ERC1967Proxy orbProxy = new ERC1967Proxy(
             address(orbV2Implementation), ""

--- a/test/OrbV2/OrbV2.t.sol
+++ b/test/OrbV2/OrbV2.t.sol
@@ -175,7 +175,7 @@ contract InitialStateTest is OrbTestBase {
 
         assertEq(orb.price(), 0);
         assertEq(orb.keeperTaxNumerator(), 120_00);
-        assertEq(orb.royaltyNumerator(), 10_00);
+        assertEq(orb.purchaseRoyaltyNumerator(), 10_00);
         assertEq(orb.auctionRoyaltyNumerator(), 30_00);
         assertEq(orb.lastInvocationTime(), 0);
 


### PR DESCRIPTION
Addresses issues:

- H1: OrbV2 `initialize()` uses `reinitializer(2)` to disallow calls to `initializeV2()`
- M1: passing `honoredUntil` current value to `purchase()` to prevent front-running from Creators
- L2: using `abi.encodeCall` instead of `abi.encodeWithSelector`
- N1: adding security contact details to all contracts
- N2: renaming renaming `royaltyNumerator` to `purchaseRoyaltyNumerator`
- N3: removing unused import from OrbInvocationRegistry
